### PR TITLE
StopTime mapping for week-long values

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/StopTimeFieldMappingFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/StopTimeFieldMappingFactory.java
@@ -34,7 +34,7 @@ public class StopTimeFieldMappingFactory implements FieldMappingFactory {
 
   private static DecimalFormat _format = new DecimalFormat("00");
 
-  private static Pattern _pattern = Pattern.compile("^(\\d{1,2}):(\\d{2}):(\\d{2})$");
+  private static Pattern _pattern = Pattern.compile("^(\\d+):(\\d{2}):(\\d{2})$");
 
   public FieldMapping createFieldMapping(EntitySchemaFactory schemaFactory,
       Class<?> entityType, String csvFieldName, String objFieldName,

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/mappings/StopTimeFieldMappingFactoryTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/mappings/StopTimeFieldMappingFactoryTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2011 Geno Roupsky <geno@masconsult.eu>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs.serialization.mappings;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.onebusaway.csv_entities.CsvEntityContext;
+import org.onebusaway.csv_entities.CsvEntityContextImpl;
+import org.onebusaway.csv_entities.schema.BeanWrapper;
+import org.onebusaway.csv_entities.schema.BeanWrapperFactory;
+import org.onebusaway.csv_entities.schema.DefaultEntitySchemaFactory;
+import org.onebusaway.csv_entities.schema.FieldMapping;
+
+public class StopTimeFieldMappingFactoryTest {
+
+	@Test
+	public void test() {
+
+		StopTimeFieldMappingFactory factory = new StopTimeFieldMappingFactory();
+		DefaultEntitySchemaFactory schemaFactory = new DefaultEntitySchemaFactory();
+		String propName = "time";
+		FieldMapping mapping = factory.createFieldMapping(schemaFactory,
+				Dummy.class, propName, propName, Integer.class, true);
+
+		CsvEntityContext context = new CsvEntityContextImpl();
+
+		Map<String, Object> csvValues = new HashMap<String, Object>();
+		csvValues.put(propName, "1234:23:32");
+
+		Dummy obj = new Dummy();
+		BeanWrapper wrapped = BeanWrapperFactory.wrap(obj);
+
+		mapping.translateFromCSVToObject(context, csvValues, wrapped);
+
+		assertEquals(new Integer(1234 * 60 * 60 + 23 * 60 + 32), obj.getTime());
+
+		csvValues.clear();
+		mapping.translateFromObjectToCSV(context, wrapped, csvValues);
+		assertEquals("1234:23:32", csvValues.get(propName));
+	}
+
+	public static class Dummy {
+		private Integer time;
+
+		public void setTime(Integer time) {
+			this.time = time;
+		}
+
+		public Integer getTime() {
+			return time;
+		}
+	}
+
+}


### PR DESCRIPTION
By definition the stoptime values are limited to about 5 days long trip. In case of a longer trip the GTFS format doesn't provide a way to specify the stop time relative to the beginning.

As a simple workaround the limit for hours in stoptime fields is lifted so they can have arbitrary number of digits (at least 1 required), and any length of time can be described.
