### PR TITLE
Add RemoveRepeatedStopTimesInSameTripStrategy

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/RemoveRepeatedStopTimesInSameTripStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/RemoveRepeatedStopTimesInSameTripStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2013 Guillaume Campagna <guillaume.campagna@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add RemoveRepeatedStopTimesInSameTripStrategy because RemoveRepeatedStopTimesStrategy is removing stop times between trips in the same block. 

Removing stop times between blockID is valid when your GTFS is used only to display on a trip planner, but not in other forms. 

In our case, RemoveRepeatedStopTimesStrategy was removing the last stop of a trip when the next trip in the same block began with the same stop (and this is fairly common). 
