### PR TITLE
fix workaround for java timezone bug, and add test to ensure bug does not return

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/calendar/CalendarServiceDataFactoryImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/calendar/CalendarServiceDataFactoryImpl.java
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
  * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2013 Codemass, Inc. <aaron@codemass.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,7 +151,7 @@ public class CalendarServiceDataFactoryImpl implements
     for (Agency agency : _dao.getAllAgencies()) {
       TimeZone timeZone = TimeZone.getTimeZone(agency.getTimezone());
       if (timeZone.getID().equals("GMT")
-          && !agency.getTimezone().toUpperCase().equals("gmt")) {
+          && !agency.getTimezone().toUpperCase().equals("GMT")) {
         throw new UnknownAgencyTimezoneException(agency.getName(),
             agency.getTimezone());
       }

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/impl/calendar/CalendarServiceDataFactoryImplSyntheticTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/impl/calendar/CalendarServiceDataFactoryImplSyntheticTest.java
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
  * Copyright (C) 2012 Google, Inc.
+ * Copyright (C) 2012 Codemass, Inc. <aaron@codemass.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,10 +250,24 @@ public class CalendarServiceDataFactoryImplSyntheticTest {
 
     try {
       factory.createData();
-      fail();
+      fail("should detect that TimeZone ID is not valid");
     } catch (UnknownAgencyTimezoneException ex) {
 
     }
+  }
+
+  @Test
+  public void testGMTTimezone() throws IOException {
+    CalendarServiceDataFactoryImpl factory = new CalendarServiceDataFactoryImpl();
+
+    Agency agencyGMT = agency("G", "GMT");
+
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+    factory.setGtfsDao(dao);
+
+    saveEntities(dao, agencyGMT);
+
+    factory.createData();
   }
 
   private Agency agency(String id, String timezone) {


### PR DESCRIPTION
originally this code worked around a (reportedly) Java bug, but did so in a way that didn't actually work, so it was likely that any timezones that were actually GMT would cause a failure. Now we have a test to ensure that "GMT" as a timezone still works, and invalid timezones are still caught.
