### PR TITLE
Add support for "bikes_allowed" field in both routes.txt and trips.txt

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Route.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Route.java
@@ -28,13 +28,13 @@ public final class Route extends IdentityBean<AgencyAndId> {
   @CsvField(mapping = RouteAgencyIdFieldMappingFactory.class)
   private AgencyAndId id;
 
-  @CsvField(name="agency_id", optional = true, mapping = RouteAgencyFieldMappingFactory.class, order = -1)
+  @CsvField(name = "agency_id", optional = true, mapping = RouteAgencyFieldMappingFactory.class, order = -1)
   private Agency agency;
 
-  @CsvField(optional = true, alwaysIncludeInOutput=true)
+  @CsvField(optional = true, alwaysIncludeInOutput = true)
   private String shortName;
 
-  @CsvField(optional = true, alwaysIncludeInOutput=true)
+  @CsvField(optional = true, alwaysIncludeInOutput = true)
   private String longName;
 
   private int type;
@@ -50,8 +50,15 @@ public final class Route extends IdentityBean<AgencyAndId> {
 
   @CsvField(optional = true)
   private String textColor;
+  
+  @Deprecated
+  @CsvField(name="route_bikes_allowed", optional = true, defaultValue = "0")
+  private int routeBikesAllowed = 0;
 
-  @CsvField(optional = true, defaultValue = "0")
+  /**
+   * 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
+   */
+  @CsvField(name="bikes_allowed", optional = true, defaultValue = "0")
   private int bikesAllowed = 0;
 
   public Route() {
@@ -142,11 +149,28 @@ public final class Route extends IdentityBean<AgencyAndId> {
   public void setTextColor(String textColor) {
     this.textColor = textColor;
   }
+  
+  @Deprecated
+  public int getRouteBikesAllowed() {
+    return routeBikesAllowed;
+  }
 
+  @Deprecated
+  public void setRouteBikesAllowed(int routeBikesAllowed) {
+    this.routeBikesAllowed = routeBikesAllowed;
+  }
+
+  /**
+   * @return 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
+   */
   public int getBikesAllowed() {
     return bikesAllowed;
   }
 
+  /**
+   * @param bikesAllowed 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes
+   *          NOT allowed
+   */
   public void setBikesAllowed(int bikesAllowed) {
     this.bikesAllowed = bikesAllowed;
   }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
@@ -56,8 +56,15 @@ public final class Trip extends IdentityBean<AgencyAndId> {
   @CsvField(optional = true, defaultValue = "0")
   private int wheelchairAccessible = 0;
 
+  @Deprecated
   @CsvField(optional = true, defaultValue = "0")
   private int tripBikesAllowed = 0;
+
+  /**
+   * 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
+   */
+  @CsvField(optional = true, defaultValue = "0")
+  private int bikesAllowed = 0;
 
   public Trip() {
 
@@ -75,6 +82,7 @@ public final class Trip extends IdentityBean<AgencyAndId> {
     this.shapeId = obj.shapeId;
     this.wheelchairAccessible = obj.wheelchairAccessible;
     this.tripBikesAllowed = obj.tripBikesAllowed;
+    this.bikesAllowed = obj.bikesAllowed;
   }
 
   public AgencyAndId getId() {
@@ -157,12 +165,29 @@ public final class Trip extends IdentityBean<AgencyAndId> {
     return wheelchairAccessible;
   }
 
+  @Deprecated
   public void setTripBikesAllowed(int tripBikesAllowed) {
     this.tripBikesAllowed = tripBikesAllowed;
   }
 
+  @Deprecated
   public int getTripBikesAllowed() {
     return tripBikesAllowed;
+  }
+
+  /**
+   * @return 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
+   */
+  public int getBikesAllowed() {
+    return bikesAllowed;
+  }
+
+  /**
+   * @param bikesAllowed 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes
+   *          NOT allowed
+   */
+  public void setBikesAllowed(int bikesAllowed) {
+    this.bikesAllowed = bikesAllowed;
   }
 
   public String toString() {

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -79,13 +79,13 @@ public class GtfsReaderTest {
     gtfs.putLines(
         "routes.txt",
         "agency_id,route_id,route_short_name,route_long_name,route_type,route_desc,route_color,route_text_color,"
-            + "route_bikes_allowed,route_url",
-        "1,R1,10,The Ten,3,route desc,FF0000,0000FF,1,http://agency.gov/route");
+            + "route_bikes_allowed,bikes_allowed,route_url",
+        "1,R1,10,The Ten,3,route desc,FF0000,0000FF,1,2,http://agency.gov/route");
     gtfs.putLines(
         "trips.txt",
         "route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,shape_id,route_short_name,"
-            + "trip_bikes_allowed,wheelchair_accessible",
-        "R1,WEEK,T1,head-sign,short-name,1,B1,SHP1,10X,1,1");
+            + "trip_bikes_allowed,bikes_allowed,wheelchair_accessible",
+        "R1,WEEK,T1,head-sign,short-name,1,B1,SHP1,10X,1,2,1");
     gtfs.putLines(
         "stop_times.txt",
         "trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,"
@@ -161,7 +161,8 @@ public class GtfsReaderTest {
     assertEquals("route desc", route.getDesc());
     assertEquals("FF0000", route.getColor());
     assertEquals("0000FF", route.getTextColor());
-    assertEquals(1, route.getBikesAllowed());
+    assertEquals(1, route.getRouteBikesAllowed());
+    assertEquals(2, route.getBikesAllowed());
     assertEquals("http://agency.gov/route", route.getUrl());
 
     Trip trip = dao.getTripForId(new AgencyAndId("1", "T1"));
@@ -175,6 +176,7 @@ public class GtfsReaderTest {
     assertEquals(new AgencyAndId("1", "SHP1"), trip.getShapeId());
     assertEquals("10X", trip.getRouteShortName());
     assertEquals(1, trip.getTripBikesAllowed());
+    assertEquals(2, trip.getBikesAllowed());
     assertEquals(1, trip.getWheelchairAccessible());
 
     List<StopTime> stopTimes = dao.getStopTimesForTrip(trip);


### PR DESCRIPTION
Add support for "bikes_allowed" field in both routes.txt and trips.txt,
with 0 = undefined, 1 = bikes allowed, 2 = bikes NOT allowed.  Matches
the wheel-chair accessibility semantics.
