### PR TITLE
Add support for proposed route_sort_order field

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Route.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Route.java
@@ -25,6 +25,8 @@ public final class Route extends IdentityBean<AgencyAndId> {
 
   private static final long serialVersionUID = 1L;
 
+  private static final int MISSING_VALUE = -999;
+
   @CsvField(mapping = RouteAgencyIdFieldMappingFactory.class)
   private AgencyAndId id;
 
@@ -62,7 +64,7 @@ public final class Route extends IdentityBean<AgencyAndId> {
   private int bikesAllowed = 0;
 
   @CsvField(optional = true)
-  private String sortOrder;
+  private int sortOrder = MISSING_VALUE;
 
   public Route() {
 
@@ -179,11 +181,15 @@ public final class Route extends IdentityBean<AgencyAndId> {
     this.bikesAllowed = bikesAllowed;
   }
 
-  public String getSortOrder() {
+  public boolean isSortOrderSet() {
+    return sortOrder != MISSING_VALUE;
+  }
+
+  public int getSortOrder() {
     return sortOrder;
   }
 
-  public void setSortOrder(String sortOrder) {
+  public void setSortOrder(int sortOrder) {
     this.sortOrder = sortOrder;
   }
 

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -164,7 +164,7 @@ public class GtfsReaderTest {
     assertEquals(1, route.getRouteBikesAllowed());
     assertEquals(2, route.getBikesAllowed());
     assertEquals("http://agency.gov/route", route.getUrl());
-    assertEquals("100", route.getSortOrder());
+    assertEquals(100, route.getSortOrder());
 
     Trip trip = dao.getTripForId(new AgencyAndId("1", "T1"));
     assertEquals(new AgencyAndId("1", "T1"), trip.getId());


### PR DESCRIPTION
This PR adds support for the `route_sort_order` field, [proposed for inclusion in the GTFS standard](https://groups.google.com/d/topic/gtfs-changes/73resybBoc0/discussion) and already in use in TriMet's [GTFS feed](http://developer.trimet.org/schedule/gtfs.zip).  This is the first step toward supporting `route_sort_order` in the various OneBusAway user interfaces.
