### PR TITLE
Update Maven build to produce a shaded executable jar with all

### DIFF
--- a/onebusaway-gtfs-merge-cli/pom.xml
+++ b/onebusaway-gtfs-merge-cli/pom.xml
@@ -36,28 +36,20 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <id>jar-with-dependencies</id>
             <phase>package</phase>
             <goals>
-              <goal>single</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
-
-              <finalName>onebusaway-gtfs-merge-cli</finalName>
-
-              <archive>
-                <manifest>
+              <shadedClassifierName>withAllDependencies</shadedClassifierName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.onebusaway.gtfs_merge.GtfsMergerMain</mainClass>
-                </manifest>
-              </archive>
-
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
dependencies, similar to what we do for onebusaway-gtfs-transformer-cli.
Not sure why the assembly plugin wasn't working right, but I figure this
will at least be consistent with what we do elsewhere.
