### PR TITLE
Add single-arg constructor to AgencyAndId.

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/AgencyAndId.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/AgencyAndId.java
@@ -32,6 +32,22 @@ public class AgencyAndId implements Serializable, Comparable<AgencyAndId> {
 
   }
 
+  /**
+   * Single-argument constructor required for Jackson2/Gson de-serialization.
+   * 
+   * @param agencyAndId
+   * @throws {@link IllegalArgumentException} if {@code agencyAndId} is missing {@code ID_SEPARATOR}. 
+   */
+  public AgencyAndId(String agencyAndId) throws IllegalArgumentException {
+    String[] arr = agencyAndId.split(ID_SEPARATOR + "");
+    if (arr != null && arr.length == 2) {
+      this.agencyId = arr[0];
+      this.id = arr[1];
+    } else {
+      throw new IllegalArgumentException("invalid agency-and-id: " + agencyAndId+", expected ID_SEPARATOR '"+ID_SEPARATOR+"'");
+    }
+  }
+
   public AgencyAndId(String agencyId, String id) {
     this.agencyId = agencyId;
     this.id = id;

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/AgencyAndIdTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/AgencyAndIdTest.java
@@ -16,6 +16,7 @@
 package org.onebusaway.gtfs.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -47,4 +48,19 @@ public class AgencyAndIdTest {
     AgencyAndId id = new AgencyAndId("a","b");
     assertEquals("a_b",AgencyAndId.convertToString(id));
   }
+  
+  @Test
+  public void testSingleArgConstructor() {
+
+	AgencyAndId aaid = new AgencyAndId("a_b");
+    assertEquals("a",aaid.getAgencyId());
+    assertEquals("b",aaid.getId());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSingleArgConstructorInvalidArgumentException() {
+
+	AgencyAndId fail = new AgencyAndId("invaildBecauseNoUnderscore");
+  }
+
 }


### PR DESCRIPTION
Default JSON deserialization mechanisms in Jackson2 and Gson expect a single-argument constructor AgencyAndId(String).  Consider example bug repro.

h3. Example Bug Repro
1. client code calls route endpoint (e.g., GET "http://api.pugetsound.onebusaway.org/api/where/route/1_100175.json")
2. response contains a valid Route
3. While attempting to deserialize (for example, using Jackson2+Spring RestTemplate), the following error occurs:

```
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not instantiate value of type [simple type, class org.onebusaway.gtfs.model.AgencyAndId] from String value ('1_100175'); no single-String constructor/factory method
```
1. Sample code:

```
String url = "http://api.pugetsound.onebusaway.org/api/where/route/1_100175.json?apiKey=TEST";
Class responseType = // a simple object graph levaraging org.onebusaway.gtfs.model.Route
restTemplate.getForObject(url, responseType);
```

h2. Verification

h3. Maven Build

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] onebusaway-gtfs-modules ............................ SUCCESS [  0.563 s]
[INFO] onebusaway-gtfs .................................... SUCCESS [  6.015 s]
[INFO] onebusaway-gtfs-hibernate .......................... SUCCESS [  8.243 s]
[INFO] onebusaway-gtfs-hibernate-cli ...................... SUCCESS [  1.683 s]
[INFO] onebusaway-gtfs-transformer ........................ SUCCESS [  2.373 s]
[INFO] onebusaway-gtfs-transformer-cli .................... SUCCESS [  0.702 s]
[INFO] onebusaway-gtfs-merge .............................. SUCCESS [  1.121 s]
[INFO] onebusaway-gtfs-merge-cli .......................... SUCCESS [  0.615 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.610 s
[INFO] Finished at: 2015-07-09T08:42:39-07:00
[INFO] Final Memory: 40M/332M
[INFO] ------------------------------------------------------------------------
```

h3. Unit Test
- Added unit test to verify correctly formatted agencyAndId string
- Added unit test to verify incorrectly formatted agencyAndId string
