### PR TITLE
Fix bug in EntitiesTransformStrategy with OOO modifications

### DIFF
--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/factory/TransformFactoryTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/factory/TransformFactoryTest.java
@@ -50,7 +50,7 @@ public class TransformFactoryTest {
     GtfsTransformStrategy transform = _transformer.getLastTransform();
     assertEquals(EntitiesTransformStrategy.class, transform.getClass());
     EntitiesTransformStrategy strategy = (EntitiesTransformStrategy) transform;
-    List<MatchAndTransform> transforms = strategy.getTransformsForType(Route.class);
+    List<MatchAndTransform> transforms = strategy.getModifications();
     assertEquals(1, transforms.size());
     MatchAndTransform pair = transforms.get(0);
     EntityMatch match = pair.getMatch();
@@ -69,7 +69,7 @@ public class TransformFactoryTest {
     GtfsTransformStrategy transform = _transformer.getLastTransform();
     assertEquals(EntitiesTransformStrategy.class, transform.getClass());
     EntitiesTransformStrategy strategy = (EntitiesTransformStrategy) transform;
-    List<MatchAndTransform> transforms = strategy.getTransformsForType(Route.class);
+    List<MatchAndTransform> transforms = strategy.getModifications();
     assertEquals(1, transforms.size());
   }
 


### PR DESCRIPTION
Fix bug in EntitiesTransformStrategy where modifications were applied in an arbitrary order independent from the order in which they were added.

The previous code had been optimized to group transforms by entity type, which can cause modifications to execute in a different order than specified.