### PR TITLE
pickup_type fixer for last stops

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStoptimePickupTypeStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStoptimePickupTypeStrategy.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Finnish Traffic Agency
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_transformer.updates;
+
+import java.util.List;
+
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+
+public class LastStoptimePickupTypeStrategy implements GtfsTransformStrategy {
+
+  @Override
+  public void run(TransformContext context, GtfsMutableRelationalDao dao) {
+    for (Trip trip : dao.getAllTrips()) {
+      List<StopTime> stopTimes = dao.getStopTimesForTrip(trip);
+      if(stopTimes.size() > 0) {
+        stopTimes.get(stopTimes.size() - 1).setPickupType(1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Simple addition for fixing data that doesn't use pickup_type. Assumes that boarding is not allowed on last stops.
