### PR TITLE
Peformance improvements for GTFS merging.

### DIFF
--- a/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/strategies/scoring/TripStopsInCommonDuplicateScoringStrategy.java
+++ b/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/strategies/scoring/TripStopsInCommonDuplicateScoringStrategy.java
@@ -15,30 +15,53 @@
  */
 package org.onebusaway.gtfs_merge.strategies.scoring;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopTime;
 import org.onebusaway.gtfs.model.Trip;
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.onebusaway.gtfs_merge.GtfsMergeContext;
+import org.onebusaway.gtfs_merge.util.CacheByEntity;
+import org.onebusaway.gtfs_merge.util.CacheByEntity.CacheGetter;
 
-public class TripStopsInCommonDuplicateScoringStrategy implements
-    DuplicateScoringStrategy<Trip> {
+public class TripStopsInCommonDuplicateScoringStrategy
+    implements DuplicateScoringStrategy<Trip> {
+
+  private CacheByEntity<Trip, SortedSet<Stop>> _cache = new CacheByEntity<Trip, SortedSet<Stop>>(
+      getStops);
 
   @Override
   public double score(GtfsMergeContext context, Trip source, Trip target) {
-    Set<Stop> sourceStops = getStopsForTrip(context.getSource(), source);
-    Set<Stop> targetStops = getStopsForTrip(context.getTarget(), target);
-    return DuplicateScoringSupport.scoreElementOverlap(sourceStops, targetStops);
+    SortedSet<Stop> sourceStops = getStopsForTrip(context.getSource(), source);
+    SortedSet<Stop> targetStops = getStopsForTrip(context.getTarget(), target);
+    return DuplicateScoringSupport.scoreElementOverlap(sourceStops,
+        targetStops);
   }
 
-  private Set<Stop> getStopsForTrip(GtfsRelationalDao dao, Trip trip) {
-    Set<Stop> stops = new HashSet<Stop>();
-    for (StopTime stopTime : dao.getStopTimesForTrip(trip)) {
-      stops.add(stopTime.getStop());
-    }
-    return stops;
+  private SortedSet<Stop> getStopsForTrip(GtfsRelationalDao dao, Trip trip) {
+    return _cache.getItemForEntity(dao, trip);
   }
+
+  // It's sufficient that they're sorted in SOME way
+  private static final Comparator<Stop> stopComparator = new Comparator<Stop>() {
+    @Override
+    public int compare(Stop s, Stop t) {
+      return s.hashCode() - t.hashCode();
+    }
+  };
+
+  private static CacheGetter<Trip, SortedSet<Stop>> getStops = new CacheGetter<Trip, SortedSet<Stop>>() {
+    @Override
+    public SortedSet<Stop> getItemForEntity(GtfsRelationalDao dao, Trip trip) {
+      SortedSet<Stop> stops = new TreeSet<Stop>(stopComparator);
+
+      for (StopTime stopTime : dao.getStopTimesForTrip(trip)) {
+        stops.add(stopTime.getStop());
+      }
+      return stops;
+    }
+  };
 }

--- a/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/util/CacheByEntity.java
+++ b/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/util/CacheByEntity.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2016 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_merge.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.onebusaway.gtfs.model.IdentityBean;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+
+public class CacheByEntity<S extends IdentityBean<?>, T> {
+
+  private CacheGetter<S, T> _getter;
+  private Map<Key, T> _map = new ConcurrentHashMap<Key, T>();
+
+  public CacheByEntity(CacheGetter<S, T> getter) {
+    _getter = getter;
+  }
+
+  public T getItemForEntity(GtfsRelationalDao dao, S bean) {
+
+    Key key = new Key(dao, bean);
+
+    T item = _map.get(key);
+    if (item != null) {
+      return item;
+    }
+
+    item = _getter.getItemForEntity(dao, bean);
+    if (item != null) {
+      _map.put(key, item);
+    }
+
+    return item;
+  }
+
+  public interface CacheGetter<S extends IdentityBean<?>, T> {
+    T getItemForEntity(GtfsRelationalDao dao, S bean);
+  }
+
+  private class Key {
+    GtfsRelationalDao _dao;
+    IdentityBean<?> _bean;
+
+    Key(GtfsRelationalDao dao, IdentityBean<?> bean) {
+      _dao = dao;
+      _bean = bean;
+    }
+
+    @Override
+    public int hashCode() {
+      return (_dao.hashCode() * 71) + (700241 * _bean.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof CacheByEntity.Key)) {
+        return false;
+      }
+      if (!((CacheByEntity<?, ?>.Key) o)._dao.equals(this._dao)) {
+        return false;
+      }
+      if (!((CacheByEntity<?, ?>.Key) o)._bean.equals(this._bean)) {
+        return false;
+      }
+      return true;
+    }
+  }
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/IdentityBean.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/IdentityBean.java
@@ -64,8 +64,16 @@ public abstract class IdentityBean<T extends Serializable> implements
     return getId().equals(entity.getId());
   }
 
+  private int _hashCode;
+  private T _hashCodeSource = null;
+  
   @Override
   public int hashCode() {
-    return getId().hashCode();
+    // Cache hashCode value, which only depends on id 
+    if (getId() != _hashCodeSource) {
+      _hashCodeSource = getId();
+      _hashCode = getId().hashCode();
+    }
+    return _hashCode;
   }
 }


### PR DESCRIPTION
Focused on TripStopsInCommonDuplicateScoringStrategy (scores pairs of trips for similarity based on their serviced stops):
- Faster hashing for IdentityBeans by caching the hash in the bean.
- Added cache for the sets of stops by trip.
- Faster calculation of set intersection by using sorted sets.