### PR TITLE
AndDuplicateScoringStrategy: stop score computations if 0

### DIFF
--- a/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/strategies/scoring/AndDuplicateScoringStrategy.java
+++ b/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/strategies/scoring/AndDuplicateScoringStrategy.java
@@ -40,6 +40,9 @@ public class AndDuplicateScoringStrategy<T> implements
     double score = 1.0;
     for (DuplicateScoringStrategy<T> strategy : _strategies) {
       score *= strategy.score(context, source, target);
+      if (score == 0) {
+        break;
+      }
     }
     return score;
   }


### PR DESCRIPTION
This yields significant improvements for TripMergeStrategy, since we avoid expensive TripStopsInCommonDuplicateScoringStrategy computations for all trip pairs whose routes or serviceIds don't match.