### PR TITLE
Explicitly shut down thread pool in AbstractIdentifiableSingleEntityMergeStrategy

### DIFF
--- a/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/strategies/AbstractIdentifiableSingleEntityMergeStrategy.java
+++ b/onebusaway-gtfs-merge/src/main/java/org/onebusaway/gtfs_merge/strategies/AbstractIdentifiableSingleEntityMergeStrategy.java
@@ -217,6 +217,8 @@ public abstract class AbstractIdentifiableSingleEntityMergeStrategy<T extends Id
       // we no longer remove the best match to avoid concurrency issues
     }
 
+    executorService.shutdown();
+
     /**
      * There needs to be sufficient overlap between the two feeds for us to
      * consider using fuzzy duplicate detection in the first place.


### PR DESCRIPTION
This prevents a potential hang (more precisely, failure of the JVM to terminate because there is a thread blocking in `ThreadPoolExecutor.getTask()` waiting for a task which will never arrive) when the merge process completes.

Note that this is not the only viable solution - quoting [the Javadoc](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html):
> A pool that is no longer referenced in a program _AND_ has no remaining threads will be shutdown automatically. If you would like to ensure that unreferenced pools are reclaimed even if users forget to call `shutdown()`, then you must arrange that unused threads eventually die, by setting appropriate keep-alive times, using a lower bound of zero core threads and/or setting `allowCoreThreadTimeOut(boolean)`.