### PR TITLE
Fix #90 - Allow transfers.txt transfer_type field to be empty

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Transfer.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Transfer.java
@@ -48,6 +48,7 @@ public final class Transfer extends IdentityBean<Integer> {
   @CsvField(name = "to_trip_id", mapping = EntityFieldMappingFactory.class, optional = true)
   private Trip toTrip;
 
+  @CsvField(optional = true, defaultValue = "0", alwaysIncludeInOutput = true)
   private int transferType;
 
   @CsvField(optional = true)


### PR DESCRIPTION
According to GTFS spec (https://developers.google.com/transit/gtfs/reference/#transferstxt), while the field (i.e., header) is required, an empty value in a record is considered to be the value 0 (this project currently throws `MissingRequiredFieldException` if `transfers` value is missing).

@sheldonabrown Could you please review, and if all looks good merge and get a new release out?

This issue (#90) is blocking our gtfs-realtime-validator from evaluating valid feeds (https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/309).

I patterned this solution after both `FareAttribute.transfers` (`transfers` is a required field with an allowed optional value, but the empty value doesn't equate to any numeric value - https://developers.google.com/transit/gtfs/reference/#fare_attributestxt) and `Trip.wheelchairAccessible` (in which case an empty value for `wheelchairAccessible` equals a numeric value - https://developers.google.com/transit/gtfs/reference/#tripstxt).  It works, in that the exception is no longer thrown.

Please let me know if you think there is a better way to solve this.  Thanks!