### PR TITLE
Last stop to trip_headsign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pom.xml.releaseBackup
 .project
 .classpath
 .metadata/
+/.idea/

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/factory/TransformFactory.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/factory/TransformFactory.java
@@ -26,12 +26,7 @@ import org.onebusaway.collections.tuple.Tuples;
 import org.onebusaway.csv_entities.CsvEntityContext;
 import org.onebusaway.csv_entities.CsvEntityContextImpl;
 import org.onebusaway.csv_entities.exceptions.MissingRequiredFieldException;
-import org.onebusaway.csv_entities.schema.BeanWrapper;
-import org.onebusaway.csv_entities.schema.BeanWrapperFactory;
-import org.onebusaway.csv_entities.schema.EntitySchema;
-import org.onebusaway.csv_entities.schema.EntitySchemaFactory;
-import org.onebusaway.csv_entities.schema.FieldMapping;
-import org.onebusaway.csv_entities.schema.SingleFieldMapping;
+import org.onebusaway.csv_entities.schema.*;
 import org.onebusaway.gtfs.model.Trip;
 import org.onebusaway.gtfs_transformer.GtfsTransformer;
 import org.onebusaway.gtfs_transformer.TransformSpecificationException;
@@ -40,54 +35,22 @@ import org.onebusaway.gtfs_transformer.collections.ServiceIdKey;
 import org.onebusaway.gtfs_transformer.collections.ServiceIdKeyMatch;
 import org.onebusaway.gtfs_transformer.collections.ShapeIdKey;
 import org.onebusaway.gtfs_transformer.collections.ShapeIdKeyMatch;
-import org.onebusaway.gtfs_transformer.deferred.DeferredValueMatcher;
-import org.onebusaway.gtfs_transformer.deferred.DeferredValueSetter;
-import org.onebusaway.gtfs_transformer.deferred.EntitySchemaCache;
-import org.onebusaway.gtfs_transformer.deferred.PropertyPathExpressionValueSetter;
-import org.onebusaway.gtfs_transformer.deferred.ReplaceValueSetter;
-import org.onebusaway.gtfs_transformer.deferred.ValueSetter;
+import org.onebusaway.gtfs_transformer.deferred.*;
 import org.onebusaway.gtfs_transformer.impl.*;
-import org.onebusaway.gtfs_transformer.match.EntityMatch;
-import org.onebusaway.gtfs_transformer.match.EntityMatchCollection;
-import org.onebusaway.gtfs_transformer.match.PropertyAnyValueEntityMatch;
-import org.onebusaway.gtfs_transformer.match.PropertyValueEntityMatch;
-import org.onebusaway.gtfs_transformer.match.TypedEntityMatch;
+import org.onebusaway.gtfs_transformer.match.*;
 import org.onebusaway.gtfs_transformer.services.EntityTransformStrategy;
 import org.onebusaway.gtfs_transformer.services.GtfsEntityTransformStrategy;
 import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
 import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategyFactory;
-import org.onebusaway.gtfs_transformer.updates.CalendarExtensionStrategy;
-import org.onebusaway.gtfs_transformer.updates.CalendarSimplicationStrategy;
-import org.onebusaway.gtfs_transformer.updates.DeduplicateServiceIdsStrategy;
-import org.onebusaway.gtfs_transformer.updates.ShapeDirectionTransformStrategy;
-import org.onebusaway.gtfs_transformer.updates.ShiftNegativeStopTimesUpdateStrategy;
-import org.onebusaway.gtfs_transformer.updates.StopTimesFactoryStrategy;
-import org.onebusaway.gtfs_transformer.updates.SubsectionTripTransformStrategy;
+import org.onebusaway.gtfs_transformer.updates.*;
 import org.onebusaway.gtfs_transformer.updates.SubsectionTripTransformStrategy.SubsectionOperation;
-import org.onebusaway.gtfs_transformer.updates.TrimTripTransformStrategy;
 import org.onebusaway.gtfs_transformer.updates.TrimTripTransformStrategy.TrimOperation;
-import org.onebusaway.gtfs_transformer.updates.RemoveNonRevenueStopsStrategy;
-import org.onebusaway.gtfs_transformer.updates.RemoveNonRevenueStopsExcludingTerminalsStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringReader;
+import java.io.*;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -273,6 +236,9 @@ public class TransformFactory {
         }
         else if (opType.equals("update_trips_for_sdon")) {
           handleTransformOperation(line, json, new UpdateTripsForSdon());
+        }
+        else if (opType.equals("last_stop_to_headsign")){
+          handleTransformOperation(line, json, new LastStopToHeadsignStrategy());
         }
         else if (opType.equals("transform")) {
           handleTransformOperation(line, json);

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
@@ -1,0 +1,34 @@
+package org.onebusaway.gtfs_transformer.updates;
+
+import org.onebusaway.gtfs.model.Stop;
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class LastStopToHeadsignStrategy implements GtfsTransformStrategy {
+    // replace trip_headsign with the last stop on that trip
+    private static Logger _log = LoggerFactory.getLogger(LastStopToHeadsignStrategy.class);
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public void run(TransformContext context, GtfsMutableRelationalDao dao) {
+        for (Trip trip: dao.getAllTrips()){
+            List<StopTime> stopTimes = dao.getStopTimesForTrip(trip);
+            Stop lastStop = stopTimes.get(stopTimes.size() - 1).getStop();
+
+            trip.setTripHeadsign(lastStop.getName());
+        }
+    }
+
+
+
+}

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
@@ -1,3 +1,18 @@
+/*
+  Copyright (C) 2018 Tony Laidig
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package org.onebusaway.gtfs_transformer.updates;
 
 import org.onebusaway.gtfs.model.Stop;

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
@@ -1,4 +1,4 @@
-/*
+/**
   Copyright (C) 2018 Tony Laidig
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
- */
+ **/
 package org.onebusaway.gtfs_transformer.updates;
 
 import org.onebusaway.gtfs.model.Stop;

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategy.java
@@ -1,18 +1,18 @@
 /**
-  Copyright (C) 2018 Tony Laidig
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
- **/
+ * Copyright (C) 2018 Tony Laidig <laidig@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.onebusaway.gtfs_transformer.updates;
 
 import org.onebusaway.gtfs.model.Stop;

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
@@ -1,4 +1,4 @@
-/*
+/**
   Copyright (C) 2018 Tony Laidig
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
- */
+ **/
 
 package org.onebusaway.gtfs_transformer.updates;
 

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
@@ -1,3 +1,19 @@
+/*
+  Copyright (C) 2018 Tony Laidig
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
 package org.onebusaway.gtfs_transformer.updates;
 
 import org.junit.Assert;
@@ -31,13 +47,15 @@ public class LastStopToHeadsignStrategyTest {
     public void test() {
         LastStopToHeadsignStrategy _strategy = new LastStopToHeadsignStrategy();
 
-        _strategy.run(new TransformContext(), _dao);
         AgencyAndId tripId = new AgencyAndId();
         tripId.setId("1.1");
         tripId.setAgencyId("agency");
-
         Trip trip = _dao.getTripForId(tripId);
-        System.out.println("headsign is " + trip.getTripHeadsign());
+
+        Assert.assertNotSame("C",trip.getTripHeadsign());
+        _strategy.run(new TransformContext(), _dao);
+
+        trip = _dao.getTripForId(tripId);
         Assert.assertEquals("C",trip.getTripHeadsign());
     }
 }

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
@@ -1,0 +1,43 @@
+package org.onebusaway.gtfs_transformer.updates;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.serialization.GtfsReader;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+
+import java.io.File;
+import java.io.IOException;
+
+public class LastStopToHeadsignStrategyTest {
+    private GtfsRelationalDaoImpl _dao;
+
+    @Before
+    public void setup() throws IOException {
+        _dao = new GtfsRelationalDaoImpl();
+
+        GtfsReader reader = new GtfsReader();
+        File path = new File(getClass().getResource(
+                "/org/onebusaway/gtfs_transformer/testagency").getPath());
+        reader.setInputLocation(path);
+        reader.setEntityStore(_dao);
+        reader.run();
+    }
+
+    @Test
+    public void test() {
+        LastStopToHeadsignStrategy _strategy = new LastStopToHeadsignStrategy();
+
+        _strategy.run(new TransformContext(), _dao);
+        AgencyAndId tripId = new AgencyAndId();
+        tripId.setId("1.1");
+        tripId.setAgencyId("agency");
+
+        Trip trip = _dao.getTripForId(tripId);
+        System.out.println("headsign is " + trip.getTripHeadsign());
+        Assert.assertEquals("C",trip.getTripHeadsign());
+    }
+}

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
@@ -12,7 +12,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
- **/
+ */
 
 package org.onebusaway.gtfs_transformer.updates;
 

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
@@ -1,17 +1,17 @@
 /**
-  Copyright (C) 2018 Tony Laidig
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+ * Copyright (C) 2018 Tony Laidig <laidig@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.onebusaway.gtfs_transformer.updates;

--- a/src/site/apt/onebusaway-gtfs-transformer-cli.apt.vm
+++ b/src/site/apt/onebusaway-gtfs-transformer-cli.apt.vm
@@ -395,6 +395,14 @@ such that the resulting schedule is semantically the same.
 {"op":"remove_non_revenue_stops_excluding_terminals"}}
 +---+
 
+* Replacing trip_headsign with the last stop
+
+  Certain feeds contain unhelpful or incorrect trip_headsign. They can be replaced with the last stop's stop_name.
+
++---+
+{"op":"last_stop_to_headsign"}
++---+
+
 * Arbitrary Transform
 
   We also allow you to specify arbitrary transformations as well.  Here, you specify your transformation class and we will


### PR DESCRIPTION
**Summary:**

I've come across several feeds recently that have an unhelpful trip_headsign. This at least replaces it with the last stop.

**Expected behavior:** 

trip_headsign is replaced with the last stop. Unit tests included, passes on my travis instance.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X ] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ N/A ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ N/A ] Linked all relevant issues
