### PR TITLE
Fix tests when run from a directory with spaces in its path.

### DIFF
--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/EntityRetentionGraphTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/EntityRetentionGraphTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 
 import org.junit.Before;
@@ -39,13 +40,13 @@ public class EntityRetentionGraphTest {
   private EntityRetentionGraph _graph;
 
   @Before
-  public void setup() throws IOException {
+  public void setup() throws IOException, URISyntaxException {
     _dao = new GtfsRelationalDaoImpl();
     _graph = new EntityRetentionGraph(_dao);
 
     GtfsReader reader = new GtfsReader();
     File path = new File(getClass().getResource(
-        "/org/onebusaway/gtfs_transformer/testagency").getPath());
+        "/org/onebusaway/gtfs_transformer/testagency").toURI());
     reader.setInputLocation(path);
     reader.setEntityStore(_dao);
     reader.run();

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/LastStopToHeadsignStrategyTest.java
@@ -27,17 +27,18 @@ import org.onebusaway.gtfs_transformer.services.TransformContext;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 public class LastStopToHeadsignStrategyTest {
     private GtfsRelationalDaoImpl _dao;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws IOException, URISyntaxException {
         _dao = new GtfsRelationalDaoImpl();
 
         GtfsReader reader = new GtfsReader();
         File path = new File(getClass().getResource(
-                "/org/onebusaway/gtfs_transformer/testagency").getPath());
+                "/org/onebusaway/gtfs_transformer/testagency").toURI());
         reader.setInputLocation(path);
         reader.setEntityStore(_dao);
         reader.run();


### PR DESCRIPTION
**Summary:**

Tests failed if run from a directory with spaces in the path, because `Class.getResource()` returns a `URL`, and the path component of that URL, obtained with `URL.getPath()`, is not guaranteed to be a valid filename (e.g. spaces will be URL-encoded).  However, converting the URL to an `URI` instance with `URL.getURI()` and passing that to the `File` constructor which accepts an `URI` instance will result in a valid filesystem path.

**Expected behavior:** 

Tests pass.