### PR TITLE
Add strategy to update stop.vehicle_types

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/factory/TransformFactory.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/factory/TransformFactory.java
@@ -294,6 +294,9 @@ public class TransformFactory {
         else if (opType.equals("add_omny_bus_data")) {
           handleTransformOperation(line, json, new AddOmnyBusData());
         }
+        else if (opType.equals("update_stop_vehicle_types")) {
+          handleTransformOperation(line, json, new UpdateStopVehicleTypesStrategy());
+        }
         else if (opType.equals("transform")) {
           handleTransformOperation(line, json);
         } else {

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/UpdateStopVehicleTypesStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/UpdateStopVehicleTypesStrategy.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2020 Holger Bruch <hb@mfdz.de>
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_transformer.updates;
+
+import org.onebusaway.gtfs.model.Stop;
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This <code>UpdateStopVehicleTypesStrategy</code> updates google's stops extension
+ * field vehicle_type. Providing the vehicle type for a stop allows renderers to display
+ * stops according to the route_type served.
+ * The strategy collects for every stop the route_types of routes having trips having
+ * stop_times for this stops. In case all route_types are the same, this is attributed
+ * as vehicle_type. In case route_types differ, this strategy tries to generalize the
+ * route_types (using standard GTFS route_types or the top level extension codes). If these
+ * are still not unique, -999 is returned as unknown values.
+ * Note that the extension spec does not define a UNKNOWN value. On the other hand,
+ * OBA vehicle_type is an int primitive, and we can't set it to null, so we set it to
+ * -999, which is the (private) constant for MISSING_VALUE.
+ *
+ */
+public class UpdateStopVehicleTypesStrategy implements GtfsTransformStrategy {
+  private int MISSING_VALUE = -999;
+
+  private static Logger _log = LoggerFactory.getLogger(
+      UpdateStopVehicleTypesStrategy.class);
+
+  @Override public String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override public void run(TransformContext context,
+      GtfsMutableRelationalDao dao) {
+    for (Stop stop : dao.getAllStops()) {
+      if (stop.getLocationType() == 0) {
+        updateVehicleType(stop, dao);
+      }
+    }
+  }
+
+  private void updateVehicleType(Stop stop, GtfsMutableRelationalDao dao) {
+    Set<Integer> vehicleTypes = new HashSet<>();
+    for (StopTime stopTime : dao.getStopTimesForStop(stop)) {
+      int route_type = stopTime.getTrip().getRoute().getType();
+      vehicleTypes.add(route_type);
+    }
+
+    if (vehicleTypes.size() == 1) {
+      stop.setVehicleType(vehicleTypes.iterator().next());
+    } else {
+      int vehicleType = generalizeVehicleType(vehicleTypes);
+      _log.warn("Multiple vehicleTypes for stop {} {}, setting to {}.",
+          stop.getId(), vehicleTypes, vehicleType);
+      stop.setVehicleType(vehicleType);
+    }
+  }
+
+  private int generalizeVehicleType(Set<Integer> vehicleTypes) {
+    Set<Integer> generalizedVehicleTypes = new HashSet<>();
+    for (int vehicleType : vehicleTypes) {
+      generalizedVehicleTypes.add(mapToStandardRouteType(vehicleType));
+    }
+    if (generalizedVehicleTypes.size() == 1) {
+      return generalizedVehicleTypes.iterator().next();
+    } else {
+      return MISSING_VALUE;
+    }
+  }
+
+  private int mapToStandardRouteType(int routeType) {
+    if (routeType >= 0 && routeType <= 12) { // standard routeType
+      return routeType;
+    } else if (routeType >= 100 && routeType < 200) { // Railway Service
+      return 2;
+    } else if (routeType >= 200 && routeType < 300) { //Coach Service
+      return 3;
+    } else if (routeType >= 300 && routeType
+        < 500) { //Suburban Railway Service and Urban Railway service
+      if (routeType >= 401 && routeType <= 402) {
+        return 1;
+      }
+      return 2;
+    } else if (routeType >= 500
+        && routeType < 700) { //Metro Service and Underground Service
+      return 1;
+    } else if (routeType >= 700
+        && routeType < 900) { //Bus Service and Trolleybus service
+      return 3;
+    } else if (routeType >= 900 && routeType < 1000) { //Tram service
+      return 0;
+    } else if (routeType >= 1000
+        && routeType < 1100) { //Water Transport Service
+      return 4;
+    } else if (routeType >= 1100 && routeType < 1200) { //Air Service
+      return 1100;
+    } else if (routeType >= 1200 && routeType < 1300) { //Ferry Service
+      return 4;
+    } else if (routeType >= 1300 && routeType < 1400) { //Telecabin Service
+      return 6;
+    } else if (routeType >= 1400 && routeType < 1500) { //Funicalar Service
+      return 7;
+    } else if (routeType >= 1500 && routeType < 1600) { //Taxi Service
+      return 1500;
+    } else if (routeType >= 1600 && routeType < 1700) { //Self drive
+      return 1600;
+    } else if (routeType >= 1700 && routeType < 1800) {
+      return 1700;
+    }
+    return MISSING_VALUE;
+  }
+}

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/UpdateStopVehicleTypesStrategyTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/updates/UpdateStopVehicleTypesStrategyTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2020 Holger Bruch <hb@mfdz.de>
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_transformer.updates;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs.services.MockGtfs;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author hbruch
+ */
+public class UpdateStopVehicleTypesStrategyTest {
+
+  private UpdateStopVehicleTypesStrategy _strategy = new UpdateStopVehicleTypesStrategy();
+
+  private MockGtfs _gtfs;
+
+  @Before public void before() throws IOException {
+    _gtfs = MockGtfs.create();
+  }
+
+  @Test public void test() throws IOException {
+    _gtfs.putAgencies(1);
+    _gtfs.putStops(4);
+    _gtfs.putLines("routes.txt", "route_id,route_short_name,route_type",
+        "r0,2,1", "r1,500,500", "r2,2,2");
+    _gtfs.putCalendars(1, "start_date=20120903", "end_date=20121016",
+        "mask=1111100");
+    _gtfs.putLines("trips.txt", "trip_id,route_id,service_id,direction_id",
+        "t0,r0,sid0,0", "t1,r1,sid0,1", "t2,r2,sid0,1");
+    _gtfs.putLines("stop_times.txt",
+        "trip_id,stop_id,stop_sequence,arrival_time,departure_time",
+        "t0,s0,0,01:00:00,01:05:00", "t0,s1,1,01:30:00,01:30:00",
+        "t1,s1,1,01:30:00,01:30:00", "t1,s2,2,02:30:00,02:30:00",
+        "t2,s2,1,01:30:00,01:30:00", "t2,s3,2,02:30:00,02:30:00");
+
+    GtfsMutableRelationalDao dao = _gtfs.read();
+    TransformContext tc = new TransformContext();
+    tc.setDefaultAgencyId("a0");
+
+    _strategy.run(tc, dao);
+
+    UpdateLibrary.clearDaoCache(dao);
+
+    assertEquals("Vehicle Type for single route_type", 1,
+        getVehicleType(dao, "s0"));
+    assertEquals("Vehicle Type for multiple mergeable route_types", 1,
+        getVehicleType(dao, "s1"));
+    assertEquals("Vehicle Type for unmergeable route_types do not match", -999,
+        getVehicleType(dao, "s2"));
+
+  }
+
+  private int getVehicleType(GtfsMutableRelationalDao dao, String stopId) {
+    return dao.getStopForId(new AgencyAndId("a0", stopId)).getVehicleType();
+  }
+}


### PR DESCRIPTION
**Summary:**
The optional extension field stop.vehicle_type indicates which route_types are served at a stop. It may be used e.g. to visualize stops in maps accordingly.

This strategy collects all route_types via all stop_times/trips at each individual stop. In case multiple route_types are served, it tries to map extended route_types to GTFS standard route_types. If still then route_types are inconsistent, a missing value of -999 is set.

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes" (unchecked, as this is not a fix)
- [ ] Linked all relevant issues (unchecked, as searching for vehicle_type did not list any relevant issues)
- [x] Added unit test for new functionality

