### PR TITLE
1.3.61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ pom.xml.releaseBackup
 .classpath
 .metadata/
 /.idea/
+/onebusaway-gtfs-transformer/onebusaway-gtfs-transformer.iml
+/onebusaway-gtfs-transformer/pom.xml.versionsBackup
+/onebusaway-gtfs-modules.iml
+/pom.xml.versionsBackup

--- a/onebusaway-gtfs-hibernate-cli/pom.xml
+++ b/onebusaway-gtfs-hibernate-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
   </parent>
   <artifactId>onebusaway-gtfs-hibernate-cli</artifactId>
   <name>onebusaway-gtfs-hibernate-cli</name>

--- a/onebusaway-gtfs-hibernate-cli/pom.xml
+++ b/onebusaway-gtfs-hibernate-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-gtfs-hibernate-cli</artifactId>
   <name>onebusaway-gtfs-hibernate-cli</name>

--- a/onebusaway-gtfs-hibernate/pom.xml
+++ b/onebusaway-gtfs-hibernate/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
   </parent>
 
   <dependencies>

--- a/onebusaway-gtfs-hibernate/pom.xml
+++ b/onebusaway-gtfs-hibernate/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/onebusaway-gtfs-merge-cli/pom.xml
+++ b/onebusaway-gtfs-merge-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>onebusaway-gtfs-modules</artifactId>
     <groupId>org.onebusaway</groupId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>onebusaway-gtfs-merge-cli</artifactId>

--- a/onebusaway-gtfs-merge-cli/pom.xml
+++ b/onebusaway-gtfs-merge-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>onebusaway-gtfs-modules</artifactId>
     <groupId>org.onebusaway</groupId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>onebusaway-gtfs-merge-cli</artifactId>

--- a/onebusaway-gtfs-merge/pom.xml
+++ b/onebusaway-gtfs-merge/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>onebusaway-gtfs-modules</artifactId>
     <groupId>org.onebusaway</groupId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>onebusaway-gtfs-merge</artifactId>

--- a/onebusaway-gtfs-merge/pom.xml
+++ b/onebusaway-gtfs-merge/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>onebusaway-gtfs-modules</artifactId>
     <groupId>org.onebusaway</groupId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>onebusaway-gtfs-merge</artifactId>

--- a/onebusaway-gtfs-transformer-cli-aws/pom.xml
+++ b/onebusaway-gtfs-transformer-cli-aws/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
   </parent>
 
   <properties>

--- a/onebusaway-gtfs-transformer-cli-aws/pom.xml
+++ b/onebusaway-gtfs-transformer-cli-aws/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/onebusaway-gtfs-transformer-cli/pom.xml
+++ b/onebusaway-gtfs-transformer-cli/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
   </parent>
 
   <properties>

--- a/onebusaway-gtfs-transformer-cli/pom.xml
+++ b/onebusaway-gtfs-transformer-cli/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/onebusaway-gtfs-transformer/pom.xml
+++ b/onebusaway-gtfs-transformer/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/onebusaway-gtfs-transformer/pom.xml
+++ b/onebusaway-gtfs-transformer/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
   </parent>
 
   <repositories>

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/GtfsTransformer.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/GtfsTransformer.java
@@ -30,6 +30,7 @@ import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
 import org.onebusaway.gtfs.serialization.GtfsEntitySchemaFactory;
 import org.onebusaway.gtfs.serialization.GtfsReader;
 import org.onebusaway.gtfs.serialization.GtfsWriter;
+import org.onebusaway.gtfs.serialization.RouteWriter;
 import org.onebusaway.gtfs.services.GenericMutableDao;
 import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
@@ -69,6 +70,8 @@ public class GtfsTransformer {
   
   private GtfsWriter _writer = new GtfsWriter();
 
+  private RouteWriter _routeWriter = new RouteWriter();
+
   private GtfsMutableRelationalDao _dao = new GtfsRelationalDaoImpl();
 
   private String _agencyId;
@@ -77,8 +80,20 @@ public class GtfsTransformer {
 
   private TransformFactory _transformFactory = new TransformFactory(this);
 
+  private boolean _writeZoneRouteMapping = false;
+
+  private String _routeMappingOutputName = "ListOfRoutesInGtfs.txt";
+
   public void setGtfsInputDirectory(File gtfsInputDirectory) {
     setGtfsInputDirectories(Arrays.asList(gtfsInputDirectory));
+  }
+
+  public void setWriteZoneRouteMapping(boolean writeZoneRouteMapping){
+    _writeZoneRouteMapping = writeZoneRouteMapping;
+  }
+
+  public void setRouteMappingOutputName(String routeMappingOutputName){
+    _routeMappingOutputName = routeMappingOutputName;
   }
 
   public void setGtfsReferenceDirectory(File referenceDirectory) {
@@ -167,6 +182,9 @@ public class GtfsTransformer {
 
     updateGtfs();
     writeGtfs();
+    if(_writeZoneRouteMapping) {
+      writeRoutes();
+    }
   }
 
   /****
@@ -244,6 +262,15 @@ public class GtfsTransformer {
     _writer.setEntitySchemaFactory(schemaFactory);
 
     _writer.run(_dao);
+  }
+
+  private void writeRoutes() throws IOException{
+    if (_outputDirectory == null) {
+      return;
+    }
+    _routeWriter.setOutputLocation(_outputDirectory);
+    _routeWriter.setRoutesOutputLocation(_routeMappingOutputName);
+    _routeWriter.run(_dao);
   }
 
   private class DaoInterceptor extends GenericMutableDaoWrapper {

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/factory/TransformFactory.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/factory/TransformFactory.java
@@ -260,6 +260,10 @@ public class TransformFactory {
         }
         else if (opType.equals("check_for_future_service")){
           handleTransformOperation(line, json, new CheckForFutureService());
+        }else if (opType.equals("remove_unused_routes")) {
+          handleTransformOperation(line, json, new RemoveUnusedRoutes());
+        } else if (opType.equals("remove_old_calendar_statements")) {
+          handleTransformOperation(line, json, new RemoveOldCalendarStatements());
         }
         else if (opType.equals("verify_future_route_service")){
           handleTransformOperation(line, json, new VerifyFutureRouteService());

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/FeedInfoFromAgencyStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/FeedInfoFromAgencyStrategy.java
@@ -33,6 +33,7 @@ public class FeedInfoFromAgencyStrategy implements GtfsTransformStrategy {
 
   private static Logger _log = LoggerFactory.getLogger(FeedInfoFromAgencyStrategy.class);
   private String agencyId;
+  private String feedVersion;
 
   @CsvField(optional = true)
   private String defaultLang = "en";
@@ -52,9 +53,14 @@ public class FeedInfoFromAgencyStrategy implements GtfsTransformStrategy {
         foundAgency = true;
         _log.info("creating feed info from matched agency " + agencyId);
         FeedInfo info = getFeedInfoFromAgency(dao, agency);
+
         // if version already present leave it alone
         if (info.getVersion() == null) {
-          addCreationTime(info, context);
+          if(feedVersion!=null){
+            info.setVersion(feedVersion);
+          } else {
+            addCreationTime(info, context);
+          }
           dao.saveOrUpdateEntity(info);
         } else {
           _log.info("found feedVersion " + info.getVersion() + ", abandoning");
@@ -103,4 +109,6 @@ public class FeedInfoFromAgencyStrategy implements GtfsTransformStrategy {
   public void setDefaultLang(String lang) {
     this.defaultLang = lang;
   }
+
+  public void setFeedVersion(String feedVersion){this.feedVersion = feedVersion;}
 }

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/FeedInfoFromAgencyStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/FeedInfoFromAgencyStrategy.java
@@ -15,6 +15,9 @@
  */
 package org.onebusaway.gtfs_transformer.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.onebusaway.csv_entities.schema.annotations.CsvField;
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.FeedInfo;
@@ -22,8 +25,13 @@ import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
 import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
 import org.onebusaway.gtfs_transformer.services.TransformContext;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 public class FeedInfoFromAgencyStrategy implements GtfsTransformStrategy {
 
+
+  private static Logger _log = LoggerFactory.getLogger(FeedInfoFromAgencyStrategy.class);
   private String agencyId;
 
   @CsvField(optional = true)
@@ -36,19 +44,55 @@ public class FeedInfoFromAgencyStrategy implements GtfsTransformStrategy {
 
   @Override
   public void run(TransformContext context, GtfsMutableRelationalDao dao) {
+
+    boolean foundAgency = false;
     for (Agency agency : dao.getAllAgencies()) {
+      _log.info("comparing agency " + agency.getId() + " to " + agencyId);
       if (agency.getId().equals(agencyId)) {
-        FeedInfo info = new FeedInfo();
-        info.setId(agencyId);
-        info.setPublisherName(agency.getName());
-        info.setPublisherUrl(agency.getUrl());
-        if (agency.getLang() == null || agency.getLang().isEmpty()) {
-          info.setLang(defaultLang);
+        foundAgency = true;
+        _log.info("creating feed info from matched agency " + agencyId);
+        FeedInfo info = getFeedInfoFromAgency(dao, agency);
+        // if version already present leave it alone
+        if (info.getVersion() == null) {
+          addCreationTime(info, context);
+          dao.saveOrUpdateEntity(info);
         } else {
-          info.setLang(agency.getLang());
+          _log.info("found feedVersion " + info.getVersion() + ", abandoning");
         }
-        dao.saveEntity(info);
       }
+    }
+    if (!foundAgency) {
+      // we didn't find the expected agency, try a default agency / first agency
+      Agency agency = dao.getAllAgencies().iterator().next();
+      FeedInfo info = getFeedInfoFromAgency(dao, agency);
+      _log.info("creating feed info from unmatched agency " + agency.getId());
+      addCreationTime(info, context);
+      dao.saveOrUpdateEntity(info);
+    }
+  }
+
+  private FeedInfo getFeedInfoFromAgency(GtfsMutableRelationalDao dao, Agency agency) {
+    FeedInfo info = dao.getFeedInfoForId(agencyId);
+    if (info == null) {
+      info = new FeedInfo();
+    }
+    info.setId(agencyId);
+    info.setPublisherName(agency.getName());
+    info.setPublisherUrl(agency.getUrl());
+    if (agency.getLang() == null || agency.getLang().isEmpty()) {
+      info.setLang(defaultLang);
+    } else {
+      info.setLang(agency.getLang());
+    }
+    return info;
+  }
+
+  private void addCreationTime(FeedInfo feedInfo, TransformContext context) {
+    Long creationTime = (Long)context.getReader().getContext().get("lastModifiedTime");
+    SimpleDateFormat df = new SimpleDateFormat("zzz: dd-MMM-yyyy HH:mm");
+    if (creationTime != null) {
+      _log.info("setting version to lastModifiedTime of " + new Date(creationTime));
+      feedInfo.setVersion(df.format(new Date(creationTime)));
     }
   }
 

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/PredateCalendars.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/PredateCalendars.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2018 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_transformer.impl;
+
+import org.onebusaway.gtfs.model.ServiceCalendar;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PredateCalendars implements GtfsTransformStrategy {
+
+    private final Logger _log = LoggerFactory.getLogger(RemoveOldCalendarStatements.class);
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public void run(TransformContext transformContext, GtfsMutableRelationalDao gtfsMutableRelationalDao) {
+        for (ServiceCalendar calendar: gtfsMutableRelationalDao.getAllCalendars()) {
+            ServiceDate today = new ServiceDate(new java.util.Date());;
+            calendar.setStartDate(today);
+        }
+    }
+}

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveOldCalendarStatements.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveOldCalendarStatements.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2018 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_transformer.impl;
+
+import org.onebusaway.gtfs.model.ServiceCalendar;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class RemoveOldCalendarStatements implements GtfsTransformStrategy {
+
+    private final Logger _log = LoggerFactory.getLogger(RemoveOldCalendarStatements.class);
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public void run(TransformContext transformContext, GtfsMutableRelationalDao gtfsMutableRelationalDao) {
+        RemoveEntityLibrary removeEntityLibrary = new RemoveEntityLibrary();
+        Set<ServiceCalendar> serviceCalendarsToRemove = new HashSet<ServiceCalendar>();
+        for (ServiceCalendar calendar: gtfsMutableRelationalDao.getAllCalendars()) {
+            java.util.Date today = new java.util.Date();
+            if (calendar.getEndDate().getAsDate().before(today)){
+                serviceCalendarsToRemove.add(calendar);
+            }
+        }
+        for (ServiceCalendar serviceCalendar : serviceCalendarsToRemove) {
+            removeEntityLibrary.removeCalendar(gtfsMutableRelationalDao, serviceCalendar.getServiceId());
+        }
+    }
+}

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveUnusedRoutes.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveUnusedRoutes.java
@@ -1,0 +1,56 @@
+
+/**
+ * Copyright (C) 2018 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_transformer.impl;
+
+import org.onebusaway.gtfs.model.Route;
+import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs_transformer.impl.RemoveEntityLibrary;
+import org.onebusaway.gtfs_transformer.services.EntityTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RemoveUnusedRoutes implements GtfsTransformStrategy {
+
+    private final Logger _log = LoggerFactory.getLogger(RemoveUnusedRoutes.class);
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public void run(TransformContext transformContext, GtfsMutableRelationalDao gtfsMutableRelationalDao) {
+        RemoveEntityLibrary removeEntityLibrary = new RemoveEntityLibrary();
+        Set<Route> routesToRemove = new HashSet<Route>();
+        for (Route route: gtfsMutableRelationalDao.getAllRoutes()) {
+            List<Trip> tripsInRoute = gtfsMutableRelationalDao.getTripsForRoute(route);
+            if (tripsInRoute.size() < 1){
+                routesToRemove.add(route);
+            }
+        }
+
+        for (Route route: routesToRemove){
+            removeEntityLibrary.removeRoute(gtfsMutableRelationalDao, route);
+        }
+    }
+}

--- a/onebusaway-gtfs/pom.xml
+++ b/onebusaway-gtfs/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61</version>
+    <version>1.3.61.1</version>
   </parent>
 
   <dependencies>

--- a/onebusaway-gtfs/pom.xml
+++ b/onebusaway-gtfs/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-gtfs-modules</artifactId>
-    <version>1.3.61.1</version>
+    <version>1.3.61.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/RouteWriter.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/RouteWriter.java
@@ -1,0 +1,51 @@
+package org.onebusaway.gtfs.serialization;
+
+import org.onebusaway.gtfs.model.Route;
+import org.onebusaway.gtfs.services.GtfsDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Collection;
+
+public class RouteWriter {
+
+    private final Logger _log = LoggerFactory.getLogger(RouteWriter.class);
+
+    private String ARG_ROUTES_OUTPUT_NAME;
+
+
+    public File _outputLocation;
+
+    public RouteWriter(){
+
+    }
+
+    public void setOutputLocation(File outputLocation){
+        _outputLocation = outputLocation;
+    }
+    public void setRoutesOutputLocation(String routesOutputName){
+        ARG_ROUTES_OUTPUT_NAME = routesOutputName;
+    }
+
+
+    public void run(GtfsDao dao) throws IOException {
+
+        Collection<Route> routes = dao.getAllRoutes();
+        String output = "";
+        for (Route route : routes) {
+            output += route.getId().getAgencyId() + "***" + route.getId().getId() +",";
+        }
+        try {
+            BufferedWriter writer = new BufferedWriter(new FileWriter(_outputLocation+"/" + ARG_ROUTES_OUTPUT_NAME));
+            writer.write(output);
+            writer.close();
+        }
+        catch (IOException exception){
+            _log.error("Issue writing listOfRoutes in ModTask/NycGtfsModTask for later use in FixedRouteValidationTask");
+        }
+    }
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/RouteWriter.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/RouteWriter.java
@@ -45,7 +45,7 @@ public class RouteWriter {
             writer.close();
         }
         catch (IOException exception){
-            _log.error("Issue writing listOfRoutes in ModTask/NycGtfsModTask for later use in FixedRouteValidationTask");
+            _log.error("Issue writing " + ARG_ROUTES_OUTPUT_NAME);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>onebusaway-gtfs-modules</artifactId>
-  <version>1.3.61</version>
+  <version>1.3.61.1</version>
   <packaging>pom</packaging>
 
   <name>onebusaway-gtfs-modules</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>onebusaway-gtfs-modules</artifactId>
-  <version>1.3.61.1</version>
+  <version>1.3.61.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>onebusaway-gtfs-modules</name>


### PR DESCRIPTION
**Summary:**
Added optional routes list output
Added RemoveUnusedRoutes transformation
Added RemoveOldCalendarStatements transformation
Updated FeedInfoFromStrategy

**Expected behavior:** 

Added RemoveUnusedRoutes transformation
 -- when this transformation is run, it should remove all routes with no trips listed for them

Added RemoveOldCalendarStatements transformation
-- when this transformation is run, it should remove all service calendar ranges and calendar_dates that have ended before the current date

Added optional routes list output
-- this option can be accessed by feeding a GtfsTransformer object's setWriteZoneRouteMapping(True). The output file can be specified with setRouteMappingOutputName(). The output is formatted as line separated list of routes.

Updated FeedInfoFromAgencyStrategy