### PR TITLE
Avoid system locales with GTFS output formatting

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/StopTimeFieldMappingFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/StopTimeFieldMappingFactory.java
@@ -17,6 +17,8 @@
 package org.onebusaway.gtfs.serialization.mappings;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,7 +34,7 @@ import org.onebusaway.csv_entities.schema.FieldMappingFactory;
 
 public class StopTimeFieldMappingFactory implements FieldMappingFactory {
 
-  private static DecimalFormat _format = new DecimalFormat("00");
+  private static DecimalFormat _format = new DecimalFormat("00", new DecimalFormatSymbols(Locale.ENGLISH));
 
   private static Pattern _pattern = Pattern.compile("^(-{0,1}\\d+):(\\d{2}):(\\d{2})$");
 


### PR DESCRIPTION
**Summary:**

Fix `getSecondsAsString` to return '-' (U+002D ASCII minus) instead of locale specific character such as '−' (U+2212 minus sign).

**Expected behavior:** 

The method `StopTimeFieldMappingFactory.getSecondsAsString` should always return ASCII minus sign as negative sign, because the output string is used GTFS output files. Therefore system locale should not affect the method behavior or return value. This software is usually running in server environments without specific locale settings, so it might not come up often.

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [X] Linked all relevant issues (I didn't find any)
