### PR TITLE
Documents regexp matching

### DIFF
--- a/src/site/apt/onebusaway-gtfs-transformer-cli.apt.vm
+++ b/src/site/apt/onebusaway-gtfs-transformer-cli.apt.vm
@@ -95,6 +95,14 @@ can be used.
 each file name in the GTFS specification.  For example, the snippet above will match any entry in `routes.txt` with a
 `route_short_name` value of `574`.
 
+* Regular Expressions
+
+  Property matching also supports regular expressions that allow you to match  property values conforming to a regexp pattern. For example, the snippet below will match any entry in `stops.txt` with a `stop_id` starting with `de:08`.
+
++---+
+{"op":..., "match":{"file":"stops.txt", "stop_id":"m/^de:08.*/"}}
++---+
+
 * Compound Property Expressions
 
   Property matching also supports compound property expressions that allow you to match across GTFS relational


### PR DESCRIPTION
**Summary:**

Adds section regarding regexp matching, which was added in 1.3.21 but apparently was not added to documentation.

**Expected behavior:** 

- [ ] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ ] Linked all relevant issues
