### PR TITLE
Fix implementation of pathway_mode, is_bidirectional, and pathway_type (deprecated)

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Pathway.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Pathway.java
@@ -48,7 +48,7 @@ public final class Pathway extends IdentityBean<AgencyAndId> {
   private AgencyAndId id;
 
   @Deprecated @CsvField(optional = true)
-  private int pathwayType;
+  private int pathwayType = MISSING_VALUE;
 
   @CsvField(name = "from_stop_id", mapping = EntityFieldMappingFactory.class)
   private Stop fromStop;
@@ -56,8 +56,10 @@ public final class Pathway extends IdentityBean<AgencyAndId> {
   @CsvField(name = "to_stop_id", mapping = EntityFieldMappingFactory.class)
   private Stop toStop;
 
+  @CsvField
   private int pathwayMode;
 
+  @CsvField
   private int isBidirectional;
 
   @CsvField(optional = true)
@@ -287,6 +289,16 @@ public final class Pathway extends IdentityBean<AgencyAndId> {
   @Deprecated
   public int getPathwayType() {
     return pathwayType;
+  }
+
+  @Deprecated
+  public boolean isPathwayTypeSet() {
+    return pathwayType != MISSING_VALUE;
+  }
+
+  @Deprecated
+  public void clearPathwayType() {
+    this.pathwayType = MISSING_VALUE;
   }
 
 


### PR DESCRIPTION
**Summary:**

`pathways.txt` was observed to serialize the deprecated `pathway_type` field with a value of `0`; in addition the required `pathway_mode` and `is_bidirectional` fields were missing from serialized output.

**Expected behavior:** 

`pathway_type` should not be serialized unless explicitly set, and `pathway_mode` and `is_bidirectional` should be present in the serialized output.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [x] Linked all relevant issues
