### PR TITLE
Add agency_email attribute to hibernate configurations

### DIFF
--- a/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/model/GtfsMapping.hibernate.xml
+++ b/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/model/GtfsMapping.hibernate.xml
@@ -31,6 +31,7 @@
         <property name="phone" />
         <property name="timezone" />
         <property name="url" />
+        <property name="email" />
     </class>
 
     <class name="org.onebusaway.gtfs.model.Block" table="gtfs_block">

--- a/onebusaway-gtfs-hibernate/src/test/java/org/onebusaway/gtfs/impl/GtfsMappingTest.java
+++ b/onebusaway-gtfs-hibernate/src/test/java/org/onebusaway/gtfs/impl/GtfsMappingTest.java
@@ -69,8 +69,8 @@ public class GtfsMappingTest {
   public void testAgency() throws CsvEntityIOException, IOException {
 
     StringBuilder b = new StringBuilder();
-    b.append("agency_id,agency_name,agency_url,agency_timezone,agency_fare_url,agency_lang,agency_phone\n");
-    b.append("1,Agency,http://agency/,Amercia/Los_Angeles,http://agency/fare_url,en,800-555-BUS1\n");
+    b.append("agency_id,agency_name,agency_url,agency_timezone,agency_fare_url,agency_lang,agency_phone,agency_email\n");
+    b.append("1,Agency,http://agency/,Amercia/Los_Angeles,http://agency/fare_url,en,800-555-BUS1,agency@email.com\n");
 
     _reader.readEntities(Agency.class, new StringReader(b.toString()));
 
@@ -82,6 +82,7 @@ public class GtfsMappingTest {
     assertEquals("http://agency/fare_url", agency.getFareUrl());
     assertEquals("en", agency.getLang());
     assertEquals("800-555-BUS1", agency.getPhone());
+    assertEquals("agency@email.com", agency.getEmail());
   }
 
   @Test

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -59,8 +59,8 @@ public class GtfsReaderTest {
         "4237385,1,599,1");
     gtfs.putLines(
         "agency.txt",
-        "agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_fare_url",
-        "1,Agency,http://agency.gov/,America/Los_Angeles,en,555-1234,http://agency.gov/fares");
+        "agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_fare_url,agency_email",
+        "1,Agency,http://agency.gov/,America/Los_Angeles,en,555-1234,http://agency.gov/fares,agency@email.com");
     gtfs.putLines("levels.txt",
             "level_id,level_index,level_name",
             "L1,-1.3,Level One");
@@ -731,8 +731,8 @@ public class GtfsReaderTest {
     GtfsReader reader = new GtfsReader();
 
     StringBuilder b = new StringBuilder();
-    b.append("agency_id,agency_name,agency_url,agency_timezone,agency_fare_url,agency_lang,agency_phone\n");
-    b.append("1,Agency,http://agency/,Amercia/Los_Angeles,http://agency/fare_url,en,800-555-BUS1\n");
+    b.append("agency_id,agency_name,agency_url,agency_timezone,agency_fare_url,agency_lang,agency_phone,agency_email\n");
+    b.append("1,Agency,http://agency/,Amercia/Los_Angeles,http://agency/fare_url,en,800-555-BUS1,agency@email.com\n");
 
     reader.readEntities(Agency.class, new StringReader(b.toString()));
 
@@ -744,6 +744,7 @@ public class GtfsReaderTest {
     assertEquals("http://agency/fare_url", agency.getFareUrl());
     assertEquals("en", agency.getLang());
     assertEquals("800-555-BUS1", agency.getPhone());
+    assertEquals("agency@email.com", agency.getEmail());
   }
 
   @Test


### PR DESCRIPTION
**Summary:**

The `agency_email` attribute already introduced for the agency entity [in the past](https://github.com/OneBusAway/onebusaway-gtfs-modules/pull/66), but it seems that this field not being
parsed as part of the hibernate import. The field is part of the GTFS spec and can be found [here](https://gtfs.org/reference/static#agencytxt). This PR should fix that.

**Expected behavior:** 

When using the hibernate `GtfsDatabaseLoaderMain` we are expecting to get the `agency_email` field to the `gtfs_agencies` table.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ ] Linked all relevant issues
