### PR TITLE
Add bikes_allowed attribute to trip entity hibernate configurations

### DIFF
--- a/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/model/GtfsMapping.hibernate.xml
+++ b/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/model/GtfsMapping.hibernate.xml
@@ -312,6 +312,7 @@
         <property name="directionId" />
         <property name="blockId" index="blockId" />
         <property name="wheelchairAccessible"/>
+        <property name="bikesAllowed"/>
     </class>
 
     <class name="org.onebusaway.gtfs.model.Ridership" table="gtfs_riderships">


### PR DESCRIPTION
**Summary:**

The `bikes_allowed` attribute already introduced for the trip entity [in the past](https://github.com/OneBusAway/onebusaway-gtfs-modules/pull/36), but it seems that this field not being
parsed as part of the hibernate import. The field is part of the GTFS spec and can be found [here](https://gtfs.org/reference/static#tripstxt). This PR should fix that.

**Expected behavior:** 

When using the hibernate `GtfsDatabaseLoaderMain` we are expecting to get the `bikes_allowed` field to the `gtfs_trips` table.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ ] Linked all relevant issues
