### PR TITLE
Fix #182 - add fare_id and other fields to Location

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Location.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Location.java
@@ -26,6 +26,12 @@ public class Location extends IdentityBean<AgencyAndId> implements StopLocation 
 
     private GeoJsonObject geometry;
 
+    private String zoneId;
+
+    private String description;
+
+    private String url;
+
     @Override
     public AgencyAndId getId() {
         return id;
@@ -50,5 +56,29 @@ public class Location extends IdentityBean<AgencyAndId> implements StopLocation 
 
     public void setGeometry(GeoJsonObject geometry) {
         this.geometry = geometry;
+    }
+
+    public String getZoneId() {
+        return zoneId;
+    }
+
+    public void setZoneId(String zoneId) {
+        this.zoneId = zoneId;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReader.java
@@ -49,7 +49,10 @@ public class LocationsGeoJSONReader {
       Location location = new Location();
       location.setId(new AgencyAndId(this.defaultAgencyId, feature.getId()));
       location.setGeometry(feature.getGeometry());
-      location.setName((String) feature.getProperties().get("name"));
+      location.setName((String) feature.getProperties().get("stop_name"));
+      location.setDescription((String) feature.getProperties().get("stop_description"));
+      location.setUrl((String) feature.getProperties().get("stop_url"));
+      location.setZoneId((String) feature.getProperties().get("zone_id"));
       locations.add(location);
     }
     return locations;

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReaderTest.java
@@ -44,6 +44,8 @@ public class LocationsGeoJSONReaderTest {
     Location location = locations.iterator().next();
 
     assertEquals("si_Wendenschlossstrasse", location.getId().getId());
+    assertEquals("Wendenschlossstrasse", location.getName());
+    assertEquals("A nice description", location.getDescription());
 
     assertTrue(location.getGeometry() instanceof Polygon);
 
@@ -54,5 +56,9 @@ public class LocationsGeoJSONReaderTest {
         new LngLatAlt(13.60879898071289, 52.43225757383383),
         new LngLatAlt(13.576526641845703, 52.44413508398945)
     ), location.getGeometry());
+
+    assertEquals("fare-zone-A", location.getZoneId());
+
+    assertEquals("http://example.com", location.getUrl());
   }
 }

--- a/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/locations.geojson
+++ b/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/locations.geojson
@@ -6,7 +6,10 @@
       "type": "Feature",
       "id": "si_Wendenschlossstrasse",
       "properties": {
-        "name": "Wendenschlossstrasse"
+        "stop_name": "Wendenschlossstrasse",
+        "stop_description": "A nice description",
+        "stop_url": "http://example.com",
+        "zone_id": "fare-zone-A"
       },
       "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
**Summary:**

GTFS Flex locations can have a zone_id field just like GTFS Static ones. The relevant part of the spec is https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md#locationsgeojson-file-added

Whilst implementing this, I noticed that there are other fields missing: `stop_url`, `stop_desc`. I also noticed that the property `name` should really be `stop_name`.

Fixes #182

**LocationGroup**

I explored if the zoneId could be added to the `StopLocation` interface so it's available in `Stop`, `Location` and `LocationGroup` however for it to work in `LocationGroup` you'd have to return a collection so I'm not sure if the extra complexity is worth it. Do you have an opinion about this?

**Expected behavior:** 

The properties listed above should be parsed correctly.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [x] Linked all relevant issues

@hannesj was the original author of this code, so perhaps he could take a look as well.