### PR TITLE
Fix #185 - Add CI workflow for Github Actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,5 @@ Explain how you expect the pull request to work in your testing (in case other p
 
 Please make sure these boxes are checked before submitting your pull request - thanks!
 
-- [ ] Run the unit tests with `mvn test` to make sure you didn't break anything
 - [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
 - [ ] Linked all relevant issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+
+    - name: Test project with Maven
+      run: mvn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,13 @@ jobs:
       with:
         java-version: 8
 
+    - name: Cache Maven dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
     - name: Test project with Maven
-      run: mvn test
+      run: mvn --no-transfer-progress test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # onebusaway-gtfs-modules
 
+[![CI](https://github.com/OneBusAway/onebusaway-gtfs-modules/actions/workflows/ci.yml/badge.svg)](https://github.com/OneBusAway/onebusaway-gtfs-modules/actions/workflows/ci.yml)
+
 A Java library for reading and writing [GTFS](https://developers.google.com/transit/gtfs) feeds, including database support.
 
 See more documentation [on the wiki](https://github.com/OneBusAway/onebusaway-gtfs-modules/wiki).


### PR DESCRIPTION
**Summary:**

This adds a CI pipeline for this project using Github Actions.

Fixes #185.

**Expected behavior:** 

See the CI pipeline that will run after having merged the PR: https://github.com/ibi-group/onebusaway-gtfs-modules/runs/4235518238?check_suite_focus=true

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [x] Linked all relevant issues
