### PR TITLE
Fix #190: update GTFS Transformer "retain" strategy to include fare support.

### DIFF
--- a/onebusaway-gtfs-hibernate/src/main/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.java
+++ b/onebusaway-gtfs-hibernate/src/main/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.java
@@ -292,6 +292,11 @@ public class HibernateGtfsRelationalDaoImpl implements GtfsMutableRelationalDao 
   }
 
   @Override
+  public List<Stop> getStopsForZoneId(String zoneId) {
+    return _ops.findByNamedQueryAndNamedParam("stopsForZoneId", "zoneId", zoneId);
+  }
+
+  @Override
   public List<Trip> getTripsForRoute(Route route) {
     return _ops.findByNamedQueryAndNamedParam("tripsByRoute", "route", route);
   }
@@ -378,6 +383,18 @@ public class HibernateGtfsRelationalDaoImpl implements GtfsMutableRelationalDao 
   public List<FareRule> getFareRulesForFareAttribute(FareAttribute fareAttribute) {
     return _ops.findByNamedQueryAndNamedParam("fareRulesForFareAttribute",
         "fareAttribute", fareAttribute);
+  }
+
+  @Override
+  public List<FareRule> getFareRulesForRoute(Route route) {
+    return _ops.findByNamedQueryAndNamedParam("fareRulesForRoute",
+            "route", route);
+  }
+
+  @Override
+  public List<FareRule> getFareRulesForZoneId(String zoneId) {
+    return _ops.findByNamedQueryAndNamedParam("fareRulesForZoneId",
+            "zoneId", zoneId);
   }
 
   @Override

--- a/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.hibernate.xml
+++ b/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.hibernate.xml
@@ -28,6 +28,9 @@
     <query name="stopsForStation" read-only="true">
         FROM Stop stop WHERE stop.parentStation = :stationId AND stop.id.agencyId = :agencyId
     </query>
+    <query name="stopsForZoneId" read-only="true">
+        FROM Stop stop WHERE stop.zoneId = :zoneId
+    </query>
     <query name="tripsByRoute" read-only="true">
         FROM Trip trip WHERE trip.route = :route
     </query>
@@ -69,6 +72,12 @@
     </query>
     <query name="fareRulesForFareAttribute" read-only="true">
         FROM FareRule fr WHERE fr.fare = :fareAttribute
+    </query>
+    <query name="fareRulesForRoute" read-only="true">
+        FROM FareRule fr WHERE fr.route = :route
+    </query>
+    <query name="fareRulesForZoneId" read-only="true">
+        FROM FareRule fr WHERE fr.originId = :zoneId OR fr.destinationId = :zoneId OR fr.containsId = :zoneId
     </query>
     <query name="ridershipsForTripId" read-only="true">
         FROM Ridership r WHERE r.tripId = :tripId

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
@@ -119,6 +119,11 @@ public class GtfsDataServiceImpl implements GtfsDataService {
     }
 
     @Override
+    public List<Stop> getStopsForZoneId(String zoneId) {
+        return _dao.getStopsForZoneId(zoneId);
+    }
+
+    @Override
     public FareRule getFareRuleForId(int id) {
         return _dao.getFareRuleForId(id);
     }
@@ -296,6 +301,16 @@ public class GtfsDataServiceImpl implements GtfsDataService {
     @Override
     public List<FareRule> getFareRulesForFareAttribute(FareAttribute fareAttribute) {
         return _dao.getFareRulesForFareAttribute(fareAttribute);
+    }
+
+    @Override
+    public List<FareRule> getFareRulesForRoute(Route route) {
+        return _dao.getFareRulesForRoute(route);
+    }
+
+    @Override
+    public List<FareRule> getFareRulesForZoneId(String zoneId) {
+        return _dao.getFareRulesForZoneId(zoneId);
     }
 
     @Override

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/services/GtfsRelationalDao.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/services/GtfsRelationalDao.java
@@ -67,6 +67,8 @@ public interface GtfsRelationalDao extends GtfsDao {
 
   public List<Stop> getStopsForStation(Stop station);
 
+  public List<Stop> getStopsForZoneId(String zoneId);
+
   /****
    * {@link Trip} Methods
    ****/
@@ -130,8 +132,13 @@ public interface GtfsRelationalDao extends GtfsDao {
 
   public List<FareRule> getFareRulesForFareAttribute(FareAttribute fareAttribute);
 
+  public List<FareRule> getFareRulesForRoute(Route route);
+
+  public List<FareRule> getFareRulesForZoneId(String zoneId);
+
   /***
    * {@link Ridership}
    */
   public List<Ridership> getRidershipForTrip(AgencyAndId tripId);
+
 }


### PR DESCRIPTION
Per issue #190, the GTFS Transformer "retain" strategy does not currently support fare_rules.txt and fare_attributes.txt when retaining a subset of a GTFS feed.  This PR adds that support.
