### PR TITLE
Update download URLs in documentation to point to repo.camsys-apps.com

### DIFF
--- a/src/site/apt/onebusaway-gtfs-hibernate-cli.apt.vm
+++ b/src/site/apt/onebusaway-gtfs-hibernate-cli.apt.vm
@@ -13,13 +13,19 @@ Getting the Application
 
   You can download the application here:
 
-#set( $url = 'http://nexus.onebusaway.org/service/local/artifact/maven/content?r=public&g=org.onebusaway&a=onebusaway-gtfs-hibernate-cli&v=' + ${currentVersion} )
-  
+#if( $currentVersion.endsWith("-SNAPSHOT"))
+  #set( $repository = 'snapshots' )
+#else
+  #set( $repository = 'releases' )
+#end
+
+#set( $url = 'https://repo.camsys-apps.com/' + $repository + '/org/onebusaway/onebusaway-gtfs-hibernate-cli/' + ${currentVersion} + '/onebusaway-gtfs-hibernate-cli-' + ${currentVersion} + '.jar' )
+
   {{{${url}}onebusaway-gtfs-hibernate-cli-${currentVersion}.jar}}
   
 Using the Application
 
-  You'll need a Java 1.6 runtime installed to run the client.  To run the application:
+  You'll need a Java 11 runtime installed to run the client.  To run the application:
 
 +---+
 java -classpath onebusaway-gtfs-hiberante-cli.jar:your-database-jdbc.jar \

--- a/src/site/apt/onebusaway-gtfs-merge-cli.apt.vm
+++ b/src/site/apt/onebusaway-gtfs-merge-cli.apt.vm
@@ -15,13 +15,19 @@ Getting the Application
 
   You can download the application here:
 
-#set( $url = 'http://nexus.onebusaway.org/service/local/artifact/maven/content?r=public&g=org.onebusaway&a=onebusaway-gtfs-merge-cli&v=' + ${currentVersion} )
+#if( $currentVersion.endsWith("-SNAPSHOT"))
+  #set( $repository = 'snapshots' )
+#else
+  #set( $repository = 'releases' )
+#end
+
+#set( $url = 'https://repo.camsys-apps.com/' + $repository + '/org/onebusaway/onebusaway-gtfs-merge-cli/' + ${currentVersion} + '/onebusaway-gtfs-merge-cli-' + ${currentVersion} + '.jar' )
   
   {{{${url}}onebusaway-gtfs-merge-cli-${currentVersion}.jar}}
   
 Using the Application
 
-  You'll need a Java 1.6 runtime installed to run the client.  To run the application:
+  You'll need a Java 11 runtime installed to run the client.  To run the application:
 
 +---+
 java -jar onebusaway-gtfs-merge-cli.jar [--args] input_gtfs_path_a input_gtfs_path_b ... output_gtfs_path

--- a/src/site/apt/onebusaway-gtfs-transformer-cli.apt.vm
+++ b/src/site/apt/onebusaway-gtfs-transformer-cli.apt.vm
@@ -15,13 +15,19 @@ Introduction
 
 Requirements
   
-  * Java 6 or greater
+  * Java 11 or greater
 
 Getting the Application
 
   You can download the application here:
 
-#set( $url = 'http://nexus.onebusaway.org/service/local/artifact/maven/content?r=public&g=org.onebusaway&a=onebusaway-gtfs-transformer-cli&v=' + ${currentVersion} )
+#if( $currentVersion.endsWith("-SNAPSHOT"))
+  #set( $repository = 'snapshots' )
+#else
+  #set( $repository = 'releases' )
+#end
+
+#set( $url = 'https://repo.camsys-apps.com/' + $repository + '/org/onebusaway/onebusaway-gtfs-transformer-cli/' + ${currentVersion} + '/onebusaway-gtfs-transformer-cli-' + ${currentVersion} + '.jar' )
   
   {{{${url}}onebusaway-gtfs-transformer-cli-${currentVersion}.jar}}
   


### PR DESCRIPTION
**Summary:**

It should be possible to obtain build artifacts for the non-library parts of `onebusaway-gtfs-modules` (i.e. the transformer, merge, and loader CLI tools).

**Expected behavior:** 

I can click a link in the documentation and download a built artifact without having to know how to construct a URL to find it in a Maven repository or use an incantation such as `mvn dependency:get -Dartifact=org.onebusaway:onebusaway-gtfs-merge-cli:1.3.110-SNAPSHOT -DremoteRepositories=https://repo.camsys-apps.com/snapshots/ -Ddest=./ -Dtransitive=false`.