### PR TITLE
Add distance related fields into FareLegRule

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareLegRule.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareLegRule.java
@@ -52,7 +52,7 @@ public final class FareLegRule extends IdentityBean<String> {
   private Double maxDistance;
 
   @CsvField(name = "distance_type", optional = true)
-  public Integer distanceType;
+  private Integer distanceType;
 
   public String getLegGroupId() {
     return legGroupId;

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareLegRule.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareLegRule.java
@@ -45,6 +45,15 @@ public final class FareLegRule extends IdentityBean<String> {
   @CsvField(name = "rider_category_id", optional = true, mapping = EntityFieldMappingFactory.class)
   private RiderCategory riderCategory;
 
+  @CsvField(name = "min_distance", optional = true)
+  private Double minDistance;
+
+  @CsvField(name = "max_distance", optional = true)
+  private Double maxDistance;
+
+  @CsvField(name = "distance_type", optional = true)
+  public Integer distanceType;
+
   public String getLegGroupId() {
     return legGroupId;
   }
@@ -113,5 +122,28 @@ public final class FareLegRule extends IdentityBean<String> {
 
   public void setRiderCategory(RiderCategory riderCategory) {
     this.riderCategory = riderCategory;
+  }
+
+  public void setMinDistance(Double minDistance) {
+    this.minDistance = minDistance;
+  }
+  public Double getMinDistance() {
+    return minDistance;
+  }
+
+  public Double getMaxDistance() {
+    return maxDistance;
+  }
+
+  public void setMaxDistance(Double maxDistance) {
+    this.maxDistance = maxDistance;
+  }
+
+  public Integer getDistanceType() {
+    return distanceType;
+  }
+
+  public void setDistanceType(Integer distanceType) {
+    this.distanceType = distanceType;
   }
 }

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -877,6 +877,21 @@ public class GtfsReaderTest {
     assertTrue(dao.hasFaresV2());
   }
 
+
+ @Test
+ public void testFaresV2Distance() throws IOException{
+    MockGtfs gtfs = MockGtfs.create();
+    gtfs.putMinimal();
+    gtfs.putLines("fare_products.txt", "fare_product_id, amount, currency", "" +
+            "fare_1,5,EUR");
+    gtfs.putLines("fare_leg_rules.txt", "network_id,min_distance,max_distance,distance_type,fare_product_id",
+            "bus,0,3,1,fare_1"
+    );
+    GtfsRelationalDao dao = processFeed(gtfs.getPath(), "1", false);
+    assertTrue(dao.getAllFareLegRules().stream().map(fareLegRule -> fareLegRule.getMaxDistance()).findFirst().get() == 3.0);
+    assertTrue(dao.getAllFareLegRules().stream().map(fareLegRule -> fareLegRule.getMinDistance()).findFirst().get() == 0.0);
+    assertTrue(dao.getAllFareLegRules().stream().map(fareLegRule -> fareLegRule.getDistanceType()).findFirst().get() == 1);
+ }
   @Test
   public void testFeedInfo() throws CsvEntityIOException, IOException {
 


### PR DESCRIPTION
**Summary:**

This PR adds distance related fields in the file fare_leg_rules.txt.

**Expected behavior:** 

The fields `min_distance`, `max_distance` and `distance_type` defined in the GTFS Fares v2 extension proposal should be correctly parsed. The changes include an additional test in the `GTFSReaderTest` in which these fields are read.

