### PR TITLE
fix - UpdateRouteNames null pointer exception

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateRouteNames.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateRouteNames.java
@@ -35,6 +35,9 @@ public class UpdateRouteNames implements GtfsTransformStrategy {
     public void run(TransformContext context, GtfsMutableRelationalDao dao) {
 
         for (Route route: dao.getAllRoutes()) {
+            if(route.getLongName()==null){
+                route.setLongName(route.getShortName());
+            }
             if (route.getLongName().endsWith(" Line")) {
                 route.setLongName(route.getLongName().replace(" Line", ""));
             }


### PR DESCRIPTION
**Summary:**

UpdateRouteNames throws a null pointer if given a route_longname that is null. 

**Expected behavior:** 

This update sets the long name to equal the short name because both cannot be null according to gtfs spec, it then continues with the regular transformation.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [x] Linked all relevant issues
