### PR TITLE
Update Jackson version

### DIFF
--- a/onebusaway-gtfs/pom.xml
+++ b/onebusaway-gtfs/pom.xml
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.0</version>
+      <version>2.13.4.2</version>
     </dependency>
     <dependency>
       <groupId>de.grundid.opendatalab</groupId>
       <artifactId>geojson-jackson</artifactId>
-      <version>1.8.1</version>
+      <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The old Jackson version has security vulnerabilities and we should update it.