### PR TITLE
Change spelling of 'drop off' to be in line with the lastest flex spec change

### DIFF
--- a/onebusaway-gtfs/pom.xml
+++ b/onebusaway-gtfs/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>de.grundid.opendatalab</groupId>

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -21,10 +21,14 @@ import org.onebusaway.csv_entities.schema.annotations.CsvFields;
 import org.onebusaway.gtfs.serialization.mappings.EntityFieldMappingFactory;
 import org.onebusaway.gtfs.serialization.mappings.StopTimeFieldMappingFactory;
 import org.onebusaway.gtfs.serialization.mappings.StopLocationFieldMappingFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @CsvFields(filename = "stop_times.txt")
 public final class StopTime extends IdentityBean<Integer> implements
     Comparable<StopTime>, StopTimeProxy {
+
+  private static Logger _log = LoggerFactory.getLogger(StopTime.class);
 
   private static final long serialVersionUID =2L;
 
@@ -55,8 +59,16 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
   private int minArrivalTime = MISSING_VALUE;
 
-  @CsvField(optional = true, name = "start_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  @CsvField(optional = true, name = "start_pickup_drop_off_window", mapping = StopTimeFieldMappingFactory.class)
   private int startPickupDropOffWindow = MISSING_VALUE;
+
+  /**
+   * @deprecated
+   * GTFS-Flex v2.1 renamed "dropoff" to "drop off": https://github.com/MobilityData/gtfs-flex/commit/547200dfb580771265ae14b07d9bfd7b91c16ed2
+   */
+  @Deprecated
+  @CsvField(optional = true, name = "start_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  public int oldSpellingOfStartPickupDropOffWindow = MISSING_VALUE;
 
   /**
    * @deprecated
@@ -66,8 +78,16 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
   private int maxDepartureTime = MISSING_VALUE;
 
-  @CsvField(optional = true, name = "end_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  @CsvField(optional = true, name = "end_pickup_drop_off_window", mapping = StopTimeFieldMappingFactory.class)
   private int endPickupDropOffWindow = MISSING_VALUE;
+
+  /**
+   * @deprecated
+   * GTFS-Flex v2.1 renamed "dropoff" to "drop off": https://github.com/MobilityData/gtfs-flex/commit/547200dfb580771265ae14b07d9bfd7b91c16ed2
+   */
+  @Deprecated
+  @CsvField(optional = true, name = "end_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  public int oldSpellingOfEndPickupDropOffWindow = MISSING_VALUE;
 
   @CsvField(optional = true)
   private int timepoint = MISSING_VALUE;
@@ -340,6 +360,8 @@ public final class StopTime extends IdentityBean<Integer> implements
   public int getStartPickupDropOffWindow() {
     if (startPickupDropOffWindow != MISSING_VALUE) {
       return startPickupDropOffWindow;
+    } else if(oldSpellingOfStartPickupDropOffWindow != MISSING_VALUE){
+      return oldSpellingOfStartPickupDropOffWindow;
     } else {
       return minArrivalTime;
     }
@@ -362,7 +384,11 @@ public final class StopTime extends IdentityBean<Integer> implements
   public int getEndPickupDropOffWindow() {
     if (endPickupDropOffWindow != MISSING_VALUE) {
       return endPickupDropOffWindow;
-    } else {
+    }
+    else if (oldSpellingOfEndPickupDropOffWindow != MISSING_VALUE) {
+      return oldSpellingOfEndPickupDropOffWindow;
+    }
+    else {
       return maxDepartureTime;
     }
   }
@@ -715,5 +741,22 @@ public final class StopTime extends IdentityBean<Integer> implements
       return;
     }
     this.freeRunningFlag = freeRunningFlag;
+  }
+  @Deprecated
+  public void setOldSpellingOfStartPickupDropOffWindow(int time) {
+    oldDropOffSpellingWarning("start");
+    this.oldSpellingOfStartPickupDropOffWindow = time;
+  }
+
+  @Deprecated
+  public void setOldSpellingOfEndPickupDropOffWindow(int time) {
+    oldDropOffSpellingWarning("end");
+    this.oldSpellingOfEndPickupDropOffWindow = time;
+  }
+
+  private static void oldDropOffSpellingWarning(String type) {
+    _log.warn("This feed uses the old spelling of '{}_pickup_drop_off_window' ('dropoff' instead of 'drop_off'). "
+            + "Compatibility will be removed in the future, so please update your feed to be in line with the latest Flex V2 spec:"
+            + " https://github.com/MobilityData/gtfs-flex/commit/547200dfb", type);
   }
 }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -759,4 +759,13 @@ public final class StopTime extends IdentityBean<Integer> implements
             + "Compatibility will be removed in the future, so please update your feed to be in line with the latest Flex V2 spec:"
             + " https://github.com/MobilityData/gtfs-flex/commit/547200dfb", type);
   }
+  @Deprecated
+  public int getOldSpellingOfStartPickupDropOffWindow() {
+    return this.oldSpellingOfStartPickupDropOffWindow;
+  }
+
+  @Deprecated
+  public int getOldSpellingOfEndPickupDropOffWindow() {
+    return oldSpellingOfEndPickupDropOffWindow;
+  }
 }

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
@@ -1,0 +1,47 @@
+package org.onebusaway.gtfs.serialization;
+
+import static junit.framework.Assert.assertEquals;
+import static org.onebusaway.gtfs.serialization.GtfsReaderTest.processFeed;
+
+import java.io.IOException;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.Test;
+import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.onebusaway.gtfs.services.MockGtfs;
+
+/**
+ * The commit https://github.com/MobilityData/gtfs-flex/commit/547200dfb580771265ae14b07d9bfd7b91c16ed2
+ * of the flex V2 spec changes the following spellings :
+ *
+ *  - start_pickup_dropoff_window -> start_pickup_drop_off_window
+ *  - end_pickup_dropoff_window -> start_pickup_drop_off_window
+ *
+ * Since it's hard to spot: the change is in the word "dropoff" vs "drop_off".
+ *
+ * This test makes sure that both spellings are understood.
+ */
+public class FlexDropOffSpellingTest {
+
+  @Test
+  public void oldSpelling() throws IOException {
+    MockGtfs gtfs = MockGtfs.create();
+    gtfs.putMinimal();
+    gtfs.putDefaultTrips();
+    gtfs.putLines(
+            "stop_times.txt",
+            "trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_booking_rule_id,drop_off_booking_rule_id,start_pickup_dropoff_window,end_pickup_dropoff_window",
+            "T10-0,,,location-123,0,headsign-1,,,10:00:00,18:00:00"
+    );
+    GtfsRelationalDao dao = processFeed(gtfs.getPath(), "1", false);
+
+    assertEquals(1, dao.getAllStopTimes().size());
+
+    StopTime stopTime = List.copyOf(dao.getAllStopTimes()).get(0);
+
+    assertEquals("1_T10-0", stopTime.getTrip().getId().toString());
+    assertEquals(LocalTime.parse("10:00").toSecondOfDay(), stopTime.getStartPickupDropOffWindow());
+    assertEquals(LocalTime.parse("18:00").toSecondOfDay(), stopTime.getEndPickupDropOffWindow());
+  }
+}

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2022 Leonard Ehrenfried <mail@leonard.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.onebusaway.gtfs.serialization;
 
 import static junit.framework.Assert.assertEquals;

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -878,8 +878,8 @@ public class GtfsReaderTest {
   }
 
 
- @Test
- public void testFaresV2Distance() throws IOException{
+  @Test
+  public void testFaresV2Distance() throws IOException{
     MockGtfs gtfs = MockGtfs.create();
     gtfs.putMinimal();
     gtfs.putLines("fare_products.txt", "fare_product_id, amount, currency", "" +
@@ -891,7 +891,8 @@ public class GtfsReaderTest {
     assertTrue(dao.getAllFareLegRules().stream().map(fareLegRule -> fareLegRule.getMaxDistance()).findFirst().get() == 3.0);
     assertTrue(dao.getAllFareLegRules().stream().map(fareLegRule -> fareLegRule.getMinDistance()).findFirst().get() == 0.0);
     assertTrue(dao.getAllFareLegRules().stream().map(fareLegRule -> fareLegRule.getDistanceType()).findFirst().get() == 1);
- }
+  }
+
   @Test
   public void testFeedInfo() throws CsvEntityIOException, IOException {
 
@@ -1047,7 +1048,7 @@ public class GtfsReaderTest {
    * Private Methods
    ****/
 
-  private GtfsRelationalDao processFeed(File resourcePath, String agencyId,
+  public static GtfsRelationalDao processFeed(File resourcePath, String agencyId,
       boolean internStrings) throws IOException {
 
     GtfsReader reader = new GtfsReader();


### PR DESCRIPTION
In September, the commit https://github.com/MobilityData/gtfs-flex/commit/547200dfb580771265ae14b07d9bfd7b91c16ed2 of the Flex V2 spec changes the following spellings:

- start_pickup_dropoff_window -> start_pickup_drop_off_window
 - end_pickup_dropoff_window -> start_pickup_drop_off_window

Since it's hard to spot: the change is in the word "dropoff" vs "drop_off".

This PR adapts to this spelling change and adds some compatibility code so you can use both (for a while).