### PR TITLE
Fix #210: make "wkt" field optional

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Area.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Area.java
@@ -30,6 +30,7 @@ public final class Area extends IdentityBean<AgencyAndId> {
   @CsvField(name="area_name", optional = true)
   private String name;
 
+  @CsvField(name="wkt", optional = true)
   private String wkt;
 
   public Area() {


### PR DESCRIPTION
**Summary:**

Fix #210

Make the `wkt` field in `areas.txt` optional.  This was causing failures in real time validation:
https://github.com/MobilityData/gtfs-realtime-validator/issues/92

**Expected behavior:** 

Explain how you expect the pull request to work in your testing (in case other platforms/versions exhibit different behavior).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [x] Linked all relevant issues
