### PR TITLE
Automatically build documenation, deploy to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
 
     - name: Test project with Maven
       run: mvn --no-transfer-progress test verify
+
+    - name: Build documentation
+      run: mvn --no-transfer-progress site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Deploy documentation to Github Pages
       # only deploy after merging to master
-      # if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: github.repository_owner == 'OneBusAway' github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: target/site/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  build:
 
     runs-on: ubuntu-latest
 
@@ -31,3 +31,10 @@ jobs:
 
     - name: Build documentation
       run: mvn --no-transfer-progress site
+
+    - name: Deploy documentation to Github Pages
+      # only deploy after merging to master
+      # if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: target/site/

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.onebusaway</groupId>
@@ -109,78 +110,79 @@
         <version>1.8.0</version>
         <scope>test</scope>
       </dependency>
-	  <dependency>
-	    <groupId>javax.xml.bind</groupId>
-	    <artifactId>jaxb-api</artifactId>
-	    <version>2.3.0</version>
-	  </dependency>
-	  <dependency>
-	    <groupId>com.sun.xml.bind</groupId>
-	    <artifactId>jaxb-core</artifactId>
-	    <version>2.3.0</version>
-	  </dependency>
-	  <dependency>
-	    <groupId>com.sun.xml.bind</groupId>
-	    <artifactId>jaxb-impl</artifactId>
-	    <version>2.3.0</version>
-	  </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
-	<build>
-		<plugins>
-			<plugin>
-				<!-- This plugin must be configured both here (for attach-javadoc during
-					release) and in "reports" (for site generation), preferably with identical
-					version numbers. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.4.1</version>
-				<configuration>
-					<!-- Turn off Java 8 strict Javadoc checking -->
-					<additionalparam>-Xdoclint:none</additionalparam>
-					<source>8</source>
-					<failOnError>false</failOnError>
-				</configuration>
-				<executions>
-					<!-- Compress Javadoc into JAR and include that JAR when deploying. -->
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-                                <version>3.10.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-                        <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-site-plugin</artifactId>
-                                <version>3.12.1</version>
-                        </plugin>
-                        <plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.1</version>
-			</plugin>
-			<plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <header>LICENSE.txt</header>
-                    <excludes combine.children="append">
-                        <exclude>**/ci.yml</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-		</plugins>
-	</build>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <!-- This plugin must be configured both here (for attach-javadoc during
+          release) and in "reports" (for site generation), preferably with identical
+          version numbers. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.4.1</version>
+        <configuration>
+          <!-- Turn off Java 8 strict Javadoc checking -->
+          <additionalparam>-Xdoclint:none</additionalparam>
+          <source>8</source>
+          <failOnError>false</failOnError>
+        </configuration>
+        <executions>
+          <!-- Compress Javadoc into JAR and include that JAR when deploying. -->
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.12.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.1</version>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <header>LICENSE.txt</header>
+          <excludes combine.children="append">
+            <exclude>**/ci.yml</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,16 @@
     </dependencies>
   </dependencyManagement>
 
-  
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.4.2</version>
+      </plugin>
+    </plugins>
+  </reporting>
+
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
 					version numbers. -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.4.1</version>
 				<configuration>
 					<!-- Turn off Java 8 strict Javadoc checking -->
 					<additionalparam>-Xdoclint:none</additionalparam>
@@ -155,12 +155,18 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.10.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
 				</configuration>
 			</plugin>
-			<plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-site-plugin</artifactId>
+                                <version>3.12.1</version>
+                        </plugin>
+                        <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.0.1</version>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project name="onebusaway-gtfs-modules">
   <body>
     <links>
-      <item name="GitHub Project" href="http://github.com/OneBusAway/onebusaway-gtfs-modules/" />
+      <item name="GitHub Project" href="https://github.com/OneBusAway/onebusaway-gtfs-modules/" />
     </links>
     <menu name="Introduction">
       <item name="About" href="/index.html" />
-      <item name="GitHub Project" href="http://github.com/OneBusAway/onebusaway-gtfs-modules/" />
+      <item name="GitHub Project" href="https://github.com/OneBusAway/onebusaway-gtfs-modules/" />
       <item name="Release Notes" href="/release-notes.html" />
       <item name="API Javadoc" href="/apidocs/index.html" />
       <item name="GTFS Database Loader" href="/onebusaway-gtfs-hibernate-cli.html" />

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -16,4 +16,9 @@
     <menu ref="reports" />
     <menu ref="modules" />
   </body>
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.1</version>
+  </skin>
 </project>


### PR DESCRIPTION
As discussed yesterday, this PR adds automatic building of the documentation to the Github Actions pipeline.

The documentation is deployed to Github Pages so you might have to got into the repo settings and allow this. I'm not sure it's on by default.

It should look like this:

![image](https://user-images.githubusercontent.com/151346/213412048-fba58326-a421-49e8-928c-1438b081a0a1.png)


It also updates a few maven plugins to the latest version. The whitespace of the POM was all over the place so I also cleaned that up. You may want to view the diff that ignores whitespace changes: https://github.com/OneBusAway/onebusaway-gtfs-modules/pull/212/files?w=1

If you want to see what it looks like, here is a preview: https://ibi-group.github.io/onebusaway-gtfs-modules/

cc @optionsome