### PR TITLE
FeedInfoFromAgencyStrat compatable with SimpleModificationStrat

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/FeedInfoFromAgencyStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/FeedInfoFromAgencyStrategy.java
@@ -31,6 +31,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 public class FeedInfoFromAgencyStrategy implements GtfsTransformStrategy {
 
@@ -77,9 +78,13 @@ public class FeedInfoFromAgencyStrategy implements GtfsTransformStrategy {
   }
 
   private FeedInfo getFeedInfoFromAgency(GtfsMutableRelationalDao dao, Agency agency) {
-    FeedInfo info = dao.getFeedInfoForId(agencyId);
-    if (info == null) {
-       info = new FeedInfo();
+    // cannot just use dao.getFeedInfoFromAgencyForId if it needs to be compatable with "update" SimpleModificationStrategy
+    FeedInfo info = dao.getAllFeedInfos().stream().
+            filter(feed->feed.getId().equals(agencyId))
+            .collect(Collectors.toMap(feed->feed.getId(), feed -> feed))
+            .get(agency.getId());
+    if (info==null) {
+      info = new FeedInfo();
     }
     info.setId(agencyId);
     info.setPublisherName(agency.getName());


### PR DESCRIPTION
**Summary:**

FeedInfoFromAgencyStrategy could create duplicates if it was run with a SimpleModificationStrategy ("update")  that changed the feed_id of a feed. 

caused by “update” transformation is not updating the feed_id key GenericDaoImpl.entitiesByClassAndId when it updates the value of feed_id (and it looks like it's not updating any of the id when changed)

sample transforms to create problem:

{"op":"update","match":{"file":"feed_info.txt"}, "update":{"feed_id": "5"}}
}}}
{"op":"transform", "class":"org.onebusaway.gtfs_transformer.impl.FeedInfoFromAgencyStrategy", "agency_id":"5"}

**Expected behavior:** 

the above sample code will no longer create duplicates

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [x] Linked all relevant issues
