### PR TITLE
Fix #217 - Make stop_id optional in the Facility class

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Facility.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Facility.java
@@ -41,7 +41,7 @@ public class Facility extends IdentityBean<AgencyAndId>{
     @CsvField(optional = true)
     private String facilityType;
 
-    @CsvField(name = "stop_id", mapping = EntityFieldMappingFactory.class)
+    @CsvField(name = "stop_id", mapping = EntityFieldMappingFactory.class, optional = true)
     private Stop stop;
 
     @CsvField(optional = true)


### PR DESCRIPTION
**Summary:**

#217 

Not all facilities are guaranteed to be associated with a specific stop, so they won't necessarily have an associated stop_id. 

**Expected behavior:** 

`facilities.txt` is loaded successfully when there are entries with empty `stop_id` fields, rather than throwing an exception when trying to map to a Stop loaded from `stops.txt`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [x] Linked all relevant issues
