### PR TITLE
Included alternate_stop_names_exceptions.txt in GTFS

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
@@ -260,6 +260,7 @@ public class GtfsDaoImpl extends GenericDaoImpl implements GtfsMutableDao {
   public FacilityPropertyDefinition getFacilityPropertiesDefinitionsForId(AgencyAndId id) { return getEntityForId(FacilityPropertyDefinition.class, id);}
   public RouteNameException getRouteNameExceptionForId(AgencyAndId id) { return getEntityForId(RouteNameException.class, id);}
   public DirectionNameException getDirectionNameExceptionForId(AgencyAndId id) { return getEntityForId(DirectionNameException.class, id);}
+  public AlternateStopNameException getAlternateStopNameExceptionForId(AgencyAndId id) { return getEntityForId(AlternateStopNameException.class, id);}
 
   public Collection<DirectionEntry> getAllDirectionEntries() {
     return getAllEntitiesForType(DirectionEntry.class);
@@ -278,6 +279,9 @@ public class GtfsDaoImpl extends GenericDaoImpl implements GtfsMutableDao {
   }
   public Collection<DirectionNameException> getAllDirectionNameExceptions() {
     return getAllEntitiesForType(DirectionNameException.class);
+  }
+  public Collection<AlternateStopNameException> getAllAlternateStopNameExceptions(){
+    return getAllEntitiesForType(AlternateStopNameException.class);
   }
 
   public Collection<WrongWayConcurrency> getAllWrongWayConcurrencies() {

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
@@ -513,7 +513,7 @@ public class GtfsDataServiceImpl implements GtfsDataService {
     public FacilityPropertyDefinition getFacilityPropertiesDefinitionsForId(AgencyAndId id) { return getEntityForId(FacilityPropertyDefinition.class, id);}
     public RouteNameException getRouteNameExceptionForId(AgencyAndId id) { return getEntityForId(RouteNameException.class, id);}
     public DirectionNameException getDirectionNameExceptionForId(AgencyAndId id) { return getEntityForId(DirectionNameException.class, id);}
-
+    public AlternateStopNameException getAlternateStopNameExceptionForId(AgencyAndId id) { return getEntityForId(AlternateStopNameException.class, id);}
     public Collection<Facility> getAllFacilities() {
         return getAllEntitiesForType(Facility.class);
     }
@@ -528,6 +528,9 @@ public class GtfsDataServiceImpl implements GtfsDataService {
     }
     public Collection<DirectionNameException> getAllDirectionNameExceptions() {
         return getAllEntitiesForType(DirectionNameException.class);
+    }
+    public Collection<AlternateStopNameException> getAllAlternateStopNameExceptions(){
+        return getAllEntitiesForType(AlternateStopNameException.class);
     }
     public Collection<DirectionEntry> getAllDirectionEntries() {
         return _dao.getAllDirectionEntries();

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/translation/TranslationServiceDataFactoryImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/translation/TranslationServiceDataFactoryImpl.java
@@ -59,6 +59,8 @@ public class TranslationServiceDataFactoryImpl implements TranslationServiceData
 
     private static final String DIRECTION_ENTRY_TABLE_NAME = "direction_entry";
 
+    private static final String ALTERNATE_STOP_NAME_EXCEPTION_TABLE_NAME = "alternate_stop_name_exception";
+
     private GtfsRelationalDao _dao;
 
     public static TranslationService getTranslationService(GtfsRelationalDao dao) {
@@ -136,6 +138,8 @@ public class TranslationServiceDataFactoryImpl implements TranslationServiceData
                 return WrongWayConcurrency.class;
             case DIRECTION_ENTRY_TABLE_NAME:
                 return DirectionEntry.class;
+            case ALTERNATE_STOP_NAME_EXCEPTION_TABLE_NAME:
+                return AlternateStopNameException.class;
         }
         return null;
     }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/AlternateStopNameException.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/AlternateStopNameException.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2022 Cambridge Systematics <csavitzky@camsys.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.onebusaway.gtfs.model;
+
+import org.onebusaway.csv_entities.schema.annotations.CsvField;
+import org.onebusaway.csv_entities.schema.annotations.CsvFields;
+
+@CsvFields(filename = "alternate_stop_names_exceptions.txt", required = false)
+public class AlternateStopNameException extends IdentityBean<Integer> {
+
+    @CsvField(ignore = true)
+    private int id;
+
+    @CsvField(optional = true)
+    int routeId;
+
+    @CsvField(optional = true)
+    int directionId;
+
+    @CsvField(optional = true)
+    int stopId;
+
+    @CsvField(optional = true)
+    String alternateStopName;
+
+    public AlternateStopNameException() {
+    }
+
+    public AlternateStopNameException(AlternateStopNameException asne) {
+        this.routeId = asne.routeId;
+        this.directionId = asne.directionId;
+        this.stopId = asne.stopId;
+        this.alternateStopName = asne.alternateStopName;
+    }
+
+
+    @Override
+    public Integer getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public int getRouteId() {
+        return routeId;
+    }
+
+    public void setRouteId(int routeId) {
+        this.routeId = routeId;
+    }
+
+    public int getDirectionId() {
+        return directionId;
+    }
+
+    public void setDirectionId(int directionId) {
+        this.directionId = directionId;
+    }
+
+    public int getStopId() {
+        return stopId;
+    }
+
+    public void setStopId(int stopId) {
+        this.stopId = stopId;
+    }
+
+    public String getAlternateStopName() {
+        return alternateStopName;
+    }
+
+    public void setAlternateStopName(String alternateStopName) {
+        this.alternateStopName = alternateStopName;
+    }
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Alternate_stop_names_exceptions.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Alternate_stop_names_exceptions.java
@@ -1,0 +1,14 @@
+package org.onebusaway.gtfs.model;
+
+import org.onebusaway.csv_entities.schema.annotations.CsvField;
+import org.onebusaway.csv_entities.schema.annotations.CsvFields;
+
+@CsvFields(filename = "alternate_stop_names_exceptions.txt", required = false)
+public class Alternate_stop_names_exceptions {
+
+    @CsvField(ignore = true)
+    private int id;
+
+    @CsvField(optional = true)
+    int routeId;
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
@@ -73,6 +73,7 @@ public class GtfsEntitySchemaFactory {
     entityClasses.add(DirectionNameException.class);
     entityClasses.add(WrongWayConcurrency.class);
     entityClasses.add(DirectionEntry.class);
+    entityClasses.add(AlternateStopNameException.class);
     return entityClasses;
   }
 

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
@@ -101,6 +101,7 @@ public class GtfsReader extends CsvEntityReader {
     _entityClasses.add(DirectionNameException.class);
     _entityClasses.add(WrongWayConcurrency.class);
     _entityClasses.add(DirectionEntry.class);
+    _entityClasses.add(AlternateStopNameException.class);
 
     CsvTokenizerStrategy tokenizerStrategy = new CsvTokenizerStrategy();
     tokenizerStrategy.getCsvParser().setTrimInitialWhitespace(true);


### PR DESCRIPTION
**Summary:**

Created AlternateStopNameException model.

Added the new model reference to the `GtfsReader` 
Added the new model reference to `TranslationServiceDataFactoryImpl.getEntityTypeForTableName`
Add an accessor to `GtfsDaoImpl` 
Add the new model reference to `GtfsEntitySchemaFactory.getEntityClasses`

**Expected behavior:** 

After a transformation the alternate_stop_names_exceptions should not be lost.


