### PR TITLE
Remove backwards-compatibility with old versions of flex

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -61,43 +61,11 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
   private int departureTime = MISSING_VALUE;
 
-  /**
-   * @deprecated
-   * GTFS-Flex v2.1 renamed this field. Use {@link #startPickupDropOffWindow} instead.
-   */
-  @Deprecated
-  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
-  private int minArrivalTime = MISSING_VALUE;
-
   @CsvField(optional = true, name = "start_pickup_drop_off_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
   private int startPickupDropOffWindow = MISSING_VALUE;
 
-  /**
-   * @deprecated
-   * GTFS-Flex v2.1 renamed "dropoff" to "drop off": https://github.com/MobilityData/gtfs-flex/commit/547200dfb580771265ae14b07d9bfd7b91c16ed2
-   */
-  @Deprecated
-  @CsvField(optional = true, name = "start_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
-  public int oldSpellingOfStartPickupDropOffWindow = MISSING_VALUE;
-
-  /**
-   * @deprecated
-   * GTFS-Flex v2.1 renamed this field. Use {@link #endPickupDropOffWindow} instead.
-   */
-  @Deprecated
-  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
-  private int maxDepartureTime = MISSING_VALUE;
-
   @CsvField(optional = true, name = "end_pickup_drop_off_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
   private int endPickupDropOffWindow = MISSING_VALUE;
-
-  /**
-   * @deprecated
-   * GTFS-Flex v2.1 renamed "dropoff" to "drop off": https://github.com/MobilityData/gtfs-flex/commit/547200dfb580771265ae14b07d9bfd7b91c16ed2
-   */
-  @Deprecated
-  @CsvField(optional = true, name = "end_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
-  public int oldSpellingOfEndPickupDropOffWindow = MISSING_VALUE;
 
   @CsvField(optional = true, defaultValue = "-999")
   private int timepoint = MISSING_VALUE;
@@ -192,9 +160,7 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.dropOffType = st.dropOffType;
     this.id = st.id;
     this.pickupType = st.pickupType;
-    this.minArrivalTime = st.minArrivalTime;
     this.startPickupDropOffWindow = st.startPickupDropOffWindow;
-    this.maxDepartureTime = st.maxDepartureTime;
     this.endPickupDropOffWindow = st.endPickupDropOffWindow;
     this.continuousPickup = st.continuousPickup;
     this.continuousDropOff = st.continuousDropOff;
@@ -411,50 +377,17 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.departureTime = MISSING_VALUE;
   }
 
-  @Deprecated
-  public int getMinArrivalTime() {
-    return minArrivalTime;
-  }
-
-  @Deprecated
-  public void setMinArrivalTime(int minArrivalTime) {
-    this.minArrivalTime = minArrivalTime;
-  }
 
   public int getStartPickupDropOffWindow() {
-    if (startPickupDropOffWindow != MISSING_VALUE) {
-      return startPickupDropOffWindow;
-    } else if(oldSpellingOfStartPickupDropOffWindow != MISSING_VALUE){
-      return oldSpellingOfStartPickupDropOffWindow;
-    } else {
-      return minArrivalTime;
-    }
+    return startPickupDropOffWindow;
   }
 
   public void setStartPickupDropOffWindow(int startPickupDropOffWindow) {
     this.startPickupDropOffWindow = startPickupDropOffWindow;
   }
 
-  @Deprecated
-  public int getMaxDepartureTime() {
-    return maxDepartureTime;
-  }
-
-  @Deprecated
-  public void setMaxDepartureTime(int maxDepartureTime) {
-    this.maxDepartureTime = maxDepartureTime;
-  }
-
   public int getEndPickupDropOffWindow() {
-    if (endPickupDropOffWindow != MISSING_VALUE) {
-      return endPickupDropOffWindow;
-    }
-    else if (oldSpellingOfEndPickupDropOffWindow != MISSING_VALUE) {
-      return oldSpellingOfEndPickupDropOffWindow;
-    }
-    else {
-      return maxDepartureTime;
-    }
+    return endPickupDropOffWindow;
   }
 
   public void setEndPickupDropOffWindow(int endPickupDropOffWindow) {
@@ -806,30 +739,11 @@ public final class StopTime extends IdentityBean<Integer> implements
     }
     this.freeRunningFlag = freeRunningFlag;
   }
-  @Deprecated
-  public void setOldSpellingOfStartPickupDropOffWindow(int time) {
-    oldDropOffSpellingWarning("start");
-    this.oldSpellingOfStartPickupDropOffWindow = time;
-  }
-
-  @Deprecated
-  public void setOldSpellingOfEndPickupDropOffWindow(int time) {
-    oldDropOffSpellingWarning("end");
-    this.oldSpellingOfEndPickupDropOffWindow = time;
-  }
 
   private static void oldDropOffSpellingWarning(String type) {
     _log.warn("This feed uses the old spelling of '{}_pickup_drop_off_window' ('dropoff' instead of 'drop_off'). "
             + "Compatibility will be removed in the future, so please update your feed to be in line with the latest Flex V2 spec:"
             + " https://github.com/MobilityData/gtfs-flex/commit/547200dfb", type);
   }
-  @Deprecated
-  public int getOldSpellingOfStartPickupDropOffWindow() {
-    return this.oldSpellingOfStartPickupDropOffWindow;
-  }
 
-  @Deprecated
-  public int getOldSpellingOfEndPickupDropOffWindow() {
-    return oldSpellingOfEndPickupDropOffWindow;
-  }
 }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -740,10 +740,4 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.freeRunningFlag = freeRunningFlag;
   }
 
-  private static void oldDropOffSpellingWarning(String type) {
-    _log.warn("This feed uses the old spelling of '{}_pickup_drop_off_window' ('dropoff' instead of 'drop_off'). "
-            + "Compatibility will be removed in the future, so please update your feed to be in line with the latest Flex V2 spec:"
-            + " https://github.com/MobilityData/gtfs-flex/commit/547200dfb", type);
-  }
-
 }

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
@@ -80,7 +80,7 @@ public class StopTimeWithUnderscoreTest {
         _gtfs.putDefaultTrips();
         _gtfs.putDefaultStops();
         _gtfs.putLines("stop_times.txt",
-                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,end_pickup_dropoff_window",
+                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,end_pickup_drop_off_window",
                 "T10-0,100,0,05:55:55,08:00:00,08:23:23", "T10-0,200,1,05:55:55,09:00:00,08:44:44");
 
         GtfsRelationalDao dao = _gtfs.read();
@@ -94,7 +94,7 @@ public class StopTimeWithUnderscoreTest {
         boolean foundUnderscoreParam = false;
         while(scan.hasNext()){
             String line = scan.nextLine();
-            if(line.contains("end_pickup_dropoff_window")){
+            if(line.contains("end_pickup_drop_off_window")){
                 foundUnderscoreParam = true;
             }
         }

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
@@ -35,7 +35,7 @@ import org.onebusaway.gtfs.services.MockGtfs;
  *
  * Since it's hard to spot: the change is in the word "dropoff" vs "drop_off".
  *
- * This test makes sure that both spellings are understood.
+ * This test makes sure that the new spelling is understood.
  */
 public class FlexDropOffSpellingTest {
 

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexDropOffSpellingTest.java
@@ -40,11 +40,6 @@ import org.onebusaway.gtfs.services.MockGtfs;
 public class FlexDropOffSpellingTest {
 
   @Test
-  public void oldSpelling() throws IOException {
-    testFlexStopTimeWithSpelling("dropoff");
-  }
-
-  @Test
   public void newSpelling() throws IOException {
     testFlexStopTimeWithSpelling("drop_off");
   }


### PR DESCRIPTION
**Summary:**

StopTime.java had accumulated quite a few spellings of the start/end of the flex windows and keeping them all in your head is confusing.

Now that the flex specification has been merged, lets remove those spellings and save everybody some head space.