### PR TITLE
aligning stoptime stop_id/location_id/location_group_id && alternate_stop_name_exceptions.txt with spec

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/AlternateStopNameException.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/AlternateStopNameException.java
@@ -26,13 +26,13 @@ public class AlternateStopNameException extends IdentityBean<Integer> {
     private int id;
 
     @CsvField(optional = true)
-    int routeId;
+    String routeId;
 
     @CsvField(optional = true)
     int directionId;
 
     @CsvField(optional = true)
-    int stopId;
+    String stopId;
 
     @CsvField(optional = true)
     String alternateStopName;
@@ -58,11 +58,11 @@ public class AlternateStopNameException extends IdentityBean<Integer> {
         this.id = id;
     }
 
-    public int getRouteId() {
+    public String getRouteId() {
         return routeId;
     }
 
-    public void setRouteId(int routeId) {
+    public void setRouteId(String routeId) {
         this.routeId = routeId;
     }
 
@@ -74,11 +74,11 @@ public class AlternateStopNameException extends IdentityBean<Integer> {
         this.directionId = directionId;
     }
 
-    public int getStopId() {
+    public String getStopId() {
         return stopId;
     }
 
-    public void setStopId(int stopId) {
+    public void setStopId(String stopId) {
         this.stopId = stopId;
     }
 

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/LocationGroup.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/LocationGroup.java
@@ -30,7 +30,7 @@ public class LocationGroup extends IdentityBean<AgencyAndId> implements StopLoca
     @CsvField(name = "location_group_id", mapping = DefaultAgencyIdFieldMappingFactory.class)
     private AgencyAndId id;
 
-    @CsvField(name = "location_group_name")
+    @CsvField(name = "location_group_name", optional = true)
     private String name;
 
     // we use a List, not Set to keep the insertion order. by definition these stops don't have an

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -280,7 +280,7 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @Override
   public StopLocation getStop() {
-    if (proxy != null) {
+    if (proxy != null & stop!=null) {
       return proxy.getStop();
     }
     return stop;
@@ -288,7 +288,7 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @Override
   public StopLocation getLocation() {
-    if (proxy != null) {
+    if (proxy != null & location!=null) {
       return proxy.getLocation();
     }
     return location;
@@ -296,7 +296,7 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @Override
   public StopLocation getLocationGroup() {
-    if (proxy != null) {
+    if (proxy != null & locationGroup!=null) {
       return proxy.getLocationGroup();
     }
     return locationGroup;


### PR DESCRIPTION
**Summary:**

according to spec:
file - alternate_stop_name_exceptions.txt, fields - route_id && stop_id allow for non-numerical values in spec

file - location_groups.txt, field - location_group_name is an optional field


merge process was propagating stop_id value to location_id, & location_group_id (which are all supposed to be mutually exclusive)
  - added test for this && added fix

**Expected behavior:** 

Explain how you expect the pull request to work in your testing (in case other platforms/versions exhibit different behavior).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ ] Linked all relevant issues
