### PR TITLE
preventing StopLocations from propogating to one another during merge

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/StopTimeArray.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/StopTimeArray.java
@@ -21,12 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.onebusaway.gtfs.model.Area;
-import org.onebusaway.gtfs.model.BookingRule;
-import org.onebusaway.gtfs.model.StopLocation;
-import org.onebusaway.gtfs.model.StopTime;
-import org.onebusaway.gtfs.model.StopTimeProxy;
-import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.model.*;
 
 public class StopTimeArray extends AbstractList<StopTime> {
 
@@ -35,6 +30,10 @@ public class StopTimeArray extends AbstractList<StopTime> {
   private Trip[] trips = new Trip[0];
 
   private StopLocation[] stops = new StopLocation[0];
+
+  private StopLocation[] locations = new StopLocation[0];
+
+  private StopLocation[] locationGroups = new StopLocation[0];
 
   private Area[] startServiceAreas = new Area[0];
 
@@ -89,6 +88,8 @@ public class StopTimeArray extends AbstractList<StopTime> {
     startServiceAreas[index] = stopTime.getStartServiceArea();
     endServiceAreas[index] = stopTime.getEndServiceArea();
     stops[index] = stopTime.getStop();
+    locations[index] = stopTime.getLocation();
+    locationGroups[index] = stopTime.getLocationGroup();
     arrivalTimes[index] = stopTime.getArrivalTime();
     departureTimes[index] = stopTime.getDepartureTime();
     timepoints[index] = stopTime.getTimepoint();
@@ -151,6 +152,8 @@ public class StopTimeArray extends AbstractList<StopTime> {
     this.startServiceAreas = Arrays.copyOf(this.startServiceAreas, newLength);
     this.endServiceAreas = Arrays.copyOf(this.endServiceAreas, newLength);
     this.stops = Arrays.copyOf(this.stops, newLength);
+    this.locationGroups = Arrays.copyOf(this.locationGroups,newLength);
+    this.locations = Arrays.copyOf(this.locations,newLength);
     this.arrivalTimes = Arrays.copyOf(this.arrivalTimes, newLength);
     this.departureTimes = Arrays.copyOf(this.departureTimes, newLength);
     this.timepoints = Arrays.copyOf(this.timepoints, newLength);
@@ -260,12 +263,12 @@ public class StopTimeArray extends AbstractList<StopTime> {
 
     @Override
     public StopLocation getLocation() {
-      return stops[index];
+      return locations[index];
     }
 
     @Override
     public StopLocation getLocationGroup() {
-      return stops[index];
+      return locationGroups[index];
     }
 
     @Override
@@ -275,12 +278,12 @@ public class StopTimeArray extends AbstractList<StopTime> {
 
     @Override
     public void setLocation(StopLocation location) {
-      stops[index] = location;
+      locations[index] = location;
     }
 
     @Override
     public void setLocationGroup(StopLocation group) {
-      stops[index] = group;
+      locationGroups[index] = group;
     }
 
     @Override

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -280,7 +280,7 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @Override
   public StopLocation getStop() {
-    if (proxy != null & stop!=null) {
+    if (proxy != null) {
       return proxy.getStop();
     }
     return stop;
@@ -288,7 +288,7 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @Override
   public StopLocation getLocation() {
-    if (proxy != null & location!=null) {
+    if (proxy != null) {
       return proxy.getLocation();
     }
     return location;
@@ -296,7 +296,7 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @Override
   public StopLocation getLocationGroup() {
-    if (proxy != null & locationGroup!=null) {
+    if (proxy != null) {
       return proxy.getLocationGroup();
     }
     return locationGroup;
@@ -309,14 +309,14 @@ public final class StopTime extends IdentityBean<Integer> implements
    *  - location group
    */
   public StopLocation getStopLocation(){
-    if(stop != null){
-      return stop;
+    if(getStop() != null){
+      return getStop();
     }
-    else if(location != null) {
-      return location;
+    else if(getLocation() != null) {
+      return getLocation();
     }
-    else if(locationGroup != null){
-      return locationGroup;
+    else if(getLocationGroup() != null){
+      return getLocationGroup();
     }
     return null;
   }
@@ -738,7 +738,7 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @Override
   public String toString() {
-    return "StopTime(seq=" + getStopSequence() + " stop=" + (getStopLocation()==null?"NuLl":getStop().getId())
+    return "StopTime(seq=" + getStopSequence() + " stop=" + (getStopLocation()==null?"NuLl":getStopLocation().getId())
         + " trip=" + (getTrip()==null?"NuLl":getTrip().getId()) + " times="
         + StopTimeFieldMappingFactory.getSecondsAsString(getArrivalTime())
         + "-"


### PR DESCRIPTION
**Summary:**

preventing StopLocations from propogating to one another during merge

StopLocations are the parent for Stop, Location, LocationGroup. Previously the merge either would cause these fields to propagate to eachother, or to keep the only the original fields in some deduplication strategies, but delete all three fields in other deduplication strategies

**Expected behavior:** 

merged stoptimes should keep the same stop_id, location_id, and location_group_id values as before they were merged.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ ] Linked all relevant issues
