### PR TITLE
Add 'cars_allowed' to Trip

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
@@ -17,6 +17,7 @@ package org.onebusaway.gtfs.model;
 
 import org.onebusaway.csv_entities.schema.annotations.CsvField;
 import org.onebusaway.csv_entities.schema.annotations.CsvFields;
+import org.onebusaway.gtfs.annotations.Experimental;
 import org.onebusaway.gtfs.serialization.mappings.DefaultAgencyIdFieldMappingFactory;
 import org.onebusaway.gtfs.serialization.mappings.EntityFieldMappingFactory;
 import org.onebusaway.gtfs.serialization.mappings.TripAgencyIdFieldMappingFactory;
@@ -100,6 +101,13 @@ public final class Trip extends IdentityBean<AgencyAndId> {
   @CsvField(optional = true, defaultValue = "0")
   private int bikesAllowed = 0;
 
+  /**
+   * 0 = unknown / unspecified, 1 = cars allowed, 2 = cars NOT allowed
+   */
+  @Experimental(proposedBy="https://github.com/google/transit/issues/466")
+  @CsvField(optional = true, defaultValue = "0")
+  private int carsAllowed = 0;
+
   // Custom extension for KCM to specify a fare per-trip
   @CsvField(optional = true)
   private String fareId;
@@ -153,6 +161,7 @@ public final class Trip extends IdentityBean<AgencyAndId> {
     this.safeDurationOffset = obj.safeDurationOffset;
     this.tripBikesAllowed = obj.tripBikesAllowed;
     this.bikesAllowed = obj.bikesAllowed;
+    this.carsAllowed = obj.carsAllowed;
     this.fareId = obj.fareId;
     this.note = obj.note;
     this.peakOffpeak = obj.peakOffpeak;
@@ -351,6 +360,21 @@ public final class Trip extends IdentityBean<AgencyAndId> {
    */
   public void setBikesAllowed(int bikesAllowed) {
     this.bikesAllowed = bikesAllowed;
+  }
+
+  /**
+   * @return 0 = unknown / unspecified, 1 = cars allowed, 2 = cars NOT allowed
+   */
+  public int getCarsAllowed() {
+    return carsAllowed;
+  }
+
+  /**
+   * @param carsAllowed 0 = unknown / unspecified, 1 = cars allowed, 2 = cars
+   *          NOT allowed
+   */
+  public void setCarsAllowed(int carsAllowed) {
+    this.carsAllowed = carsAllowed;
   }
 
   public String toString() {

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -75,8 +75,8 @@ public class GtfsReaderTest extends BaseGtfsTest {
     gtfs.putLines(
         "trips.txt",
         "route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,shape_id,route_short_name,"
-            + "trip_bikes_allowed,bikes_allowed,wheelchair_accessible,peak_offpeak",
-        "R1,WEEK,T1,head-sign,short-name,1,B1,SHP1,10X,1,2,1,3");
+            + "trip_bikes_allowed,bikes_allowed,wheelchair_accessible,peak_offpeak,cars_allowed",
+        "R1,WEEK,T1,head-sign,short-name,1,B1,SHP1,10X,1,2,1,3,1");
     gtfs.putLines(
         "stop_times.txt",
         "trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,"
@@ -210,6 +210,7 @@ public class GtfsReaderTest extends BaseGtfsTest {
     assertEquals("10X", trip.getRouteShortName());
     assertEquals(1, trip.getTripBikesAllowed());
     assertEquals(2, trip.getBikesAllowed());
+    assertEquals(1, trip.getCarsAllowed());
     assertEquals(1, trip.getWheelchairAccessible());
     assertEquals(3, trip.getPeakOffpeak());
 


### PR DESCRIPTION
**Summary:**

This pr adds a `cars_allowed` field to Trip. The field works similarly to `bikes_allowed`. The field can be useful in determining whether a car is allowed on board. For example, car ferries can use this information.

Related to https://github.com/opentripplanner/OpenTripPlanner/issues/5875.
