### PR TITLE
Remove support for many non-standard fields in trips.txt

### DIFF
--- a/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/model/GtfsMapping.hibernate.xml
+++ b/onebusaway-gtfs-hibernate/src/main/resources/org/onebusaway/gtfs/model/GtfsMapping.hibernate.xml
@@ -312,7 +312,6 @@
 
         <property name="tripShortName" />
         <property name="tripHeadsign" />
-        <property name="routeShortName" />
         <property name="directionId" />
         <property name="blockId" index="blockId" />
         <property name="wheelchairAccessible"/>

--- a/onebusaway-gtfs-hibernate/src/test/java/org/onebusaway/gtfs/impl/GtfsMappingTest.java
+++ b/onebusaway-gtfs-hibernate/src/test/java/org/onebusaway/gtfs/impl/GtfsMappingTest.java
@@ -44,7 +44,7 @@ public class GtfsMappingTest {
   private static GtfsReader _reader;
 
   @BeforeEach
-  public void setup() throws IOException {
+  public void setup() {
 
     Configuration config = new Configuration();
     config = config.configure("org/onebusaway/gtfs/hibernate-configuration.xml");

--- a/onebusaway-gtfs-hibernate/src/test/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImplCaltrainTest.java
+++ b/onebusaway-gtfs-hibernate/src/test/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImplCaltrainTest.java
@@ -226,7 +226,6 @@ public class HibernateGtfsRelationalDaoImplCaltrainTest {
     assertNull(trip.getBlockId());
     assertEquals("0", trip.getDirectionId());
     assertEquals(route, trip.getRoute());
-    assertNull(trip.getRouteShortName());
     assertEquals(aid("WD01272009"), trip.getServiceId());
     assertEquals(aid("cal_sj_sf"), trip.getShapeId());
     assertEquals("101", trip.getTripShortName());

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignByDestinationStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignByDestinationStrategy.java
@@ -50,23 +50,8 @@ public class UpdateTripHeadsignByDestinationStrategy implements GtfsTransformStr
                     trip.setTripHeadsign(tripHeadSign);
                     update++;
                 }
-                else {
-                    fallbackSetHeadsign(trip);
-                    fallback++;
-                }
-            }
-            else {
-                fallbackSetHeadsign(trip);
-                fallback++;
             }
         }
         _log.info("trip headsign update:{} fallback: {}", update, fallback);
-    }
-
-    private void fallbackSetHeadsign (Trip trip) {
-        if (trip.getTripHeadsign() == null) {
-            trip.setTripHeadsign(trip.getRouteShortName());
-
-        }
     }
 }

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignByReference.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignByReference.java
@@ -44,7 +44,6 @@ public class UpdateTripHeadsignByReference implements GtfsTransformStrategy {
     public void run(TransformContext context, GtfsMutableRelationalDao dao) {
 
         GtfsMutableRelationalDao reference = (GtfsMutableRelationalDao) context.getReferenceReader().getEntityStore();
-        String agency = reference.getAllTrips().iterator().next().getId().getAgencyId();
         ArrayList<String> missingStops = new ArrayList<>();
 
         for (Trip trip : dao.getAllTrips()) {
@@ -74,13 +73,10 @@ public class UpdateTripHeadsignByReference implements GtfsTransformStrategy {
             }
             else {
                 _log.error("No stoptimes for trip {} mta id", trip.toString(), trip.getMtaTripId());
-                if (trip.getTripHeadsign() == null && trip.getRouteShortName() == null) {
+                if (trip.getTripHeadsign() == null) {
                     //if trip has no headsign, no stoptimes and no shortname, remove it
                     _log.error("Removing trip {}", trip.getId());
                     dao.removeEntity(trip);
-                }
-                else {
-                    genericSetHeadsign(trip);
                 }
             }
         }
@@ -90,16 +86,6 @@ public class UpdateTripHeadsignByReference implements GtfsTransformStrategy {
         if (stop != null && stop.getName() != null) {
             trip.setTripHeadsign(stop.getName());
             //_log.info("Setting headsign {} on {}", stop.getName(), trip.toString());
-        }
-        else {
-            genericSetHeadsign(trip);
-        }
-    }
-
-    private void genericSetHeadsign (Trip trip) {
-        if (trip.getRouteShortName() != null) {
-            trip.setTripHeadsign(trip.getRouteShortName());
-            //_log.info("Setting headsign {} on {}", trip.getRouteShortName(), trip.toString());
         }
     }
 

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignExcludeNonreference.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignExcludeNonreference.java
@@ -62,10 +62,6 @@ public class UpdateTripHeadsignExcludeNonreference implements GtfsTransformStrat
                         trip.setTripHeadsign(tripHeadSign);
                         update++;
                     }
-                    else {
-                        fallbackSetHeadsign(trip);
-                        fallback++;
-                    }
                 }
                 else {
                     noChange++;
@@ -74,18 +70,8 @@ public class UpdateTripHeadsignExcludeNonreference implements GtfsTransformStrat
                     }
                 }
             }
-            else {
-                fallbackSetHeadsign(trip);
-                fallback++;
-            }
         }
         _log.info("trip headsign update:{} fallback: {} no change: {} shuttle: {}", update, fallback, noChange, shuttle);
-    }
-
-    private void fallbackSetHeadsign (Trip trip) {
-        if (trip.getTripHeadsign() == null) {
-            trip.setTripHeadsign(trip.getRouteShortName());
-        }
     }
 
     @CsvField(ignore = true)

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignIfNull.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignIfNull.java
@@ -44,21 +44,9 @@ public class UpdateTripHeadsignIfNull implements GtfsTransformStrategy {
                     if (tripHeadSign != null) {
                         trip.setTripHeadsign(tripHeadSign);
                     }
-                    else {
-                        fallbackSetHeadsign(trip);
-                    }
-                }
-                else {
-                    fallbackSetHeadsign(trip);
                 }
             }
         }
     }
 
-    private void fallbackSetHeadsign (Trip trip) {
-        if (trip.getTripHeadsign() == null) {
-            trip.setTripHeadsign(trip.getRouteShortName());
-            _log.info("Setting headsign to route short name: ", trip.getRouteShortName());
-        }
-    }
 }

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignRailRoadConvention.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripHeadsignRailRoadConvention.java
@@ -48,7 +48,7 @@ public class UpdateTripHeadsignRailRoadConvention implements GtfsTransformStrate
             List<StopTime> stopTimes = dao.getStopTimesForTrip(trip);
 
             if (stopTimes != null && stopTimes.size() > 0) {
-                String existingTripHeadsign = (trip.getTripHeadsign() != null) ? trip.getTripHeadsign() : trip.getRouteShortName();
+                String existingTripHeadsign = (trip.getTripHeadsign() != null) ? trip.getTripHeadsign() : "trip route short name";
             	
                 Calendar calendar = Calendar.getInstance();
                 calendar.setTimeInMillis(stopTimes.get(0).getDepartureTime() * 1000);

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/DeduplicateTripsStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/DeduplicateTripsStrategy.java
@@ -115,8 +115,6 @@ public class DeduplicateTripsStrategy implements GtfsTransformStrategy {
       return "directionId";
     if (!equals(tripA.getRoute(), tripB.getRoute()))
       return "route";
-    if (!equals(tripA.getRouteShortName(), tripB.getRouteShortName()))
-      return "routeShortName";
     if (!equals(tripA.getShapeId(), tripB.getShapeId()))
       return "shapeId";
     if (!equals(tripA.getTripHeadsign(), tripB.getTripHeadsign()))

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LocalVsExpressUpdateStrategy.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/updates/LocalVsExpressUpdateStrategy.java
@@ -71,7 +71,6 @@ public class LocalVsExpressUpdateStrategy implements GtfsTransformStrategy {
         boolean isExpress = trip.getTripShortName().equals("EXPRESS");
         if (isExpress) {
           _log.info("route(" + route.getShortName() + ") gets an E for trip " + trip.getId());
-          trip.setRouteShortName(trip.getRoute().getShortName() + "E");
           if (addLocalVsExpressToTripName) {
             String tripHeadsign = trip.getTripHeadsign();
             if (tripHeadsign != null)

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
@@ -84,10 +84,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
   @CsvField(optional = true, defaultValue = "0")
   private int carsAllowed = 0;
 
-  // Custom extension for KCM to specify a fare per-trip
-  @CsvField(optional = true)
-  private String fareId;
-
   // Custom extension for MNR
   @CsvField(optional = true, name = "note_id", mapping = EntityFieldMappingFactory.class, order = -1)
   private Note note;
@@ -129,7 +125,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
     this.safeDurationOffset = obj.safeDurationOffset;
     this.bikesAllowed = obj.bikesAllowed;
     this.carsAllowed = obj.carsAllowed;
-    this.fareId = obj.fareId;
     this.note = obj.note;
     this.peakOffpeak = obj.peakOffpeak;
     this.mtaTripId = obj.mtaTripId;
@@ -272,14 +267,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
 
   public String toString() {
     return "<Trip " + getId() + ">";
-  }
-  
-  public String getFareId() {
-	  return fareId;
-  }
-  
-  public void setFareId(String fareId) {
-	  this.fareId = fareId;
   }
 
   public Note getNote() {

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
@@ -71,10 +71,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
   private Double safeDurationOffset;
 
 
-  @Deprecated
-  @CsvField(optional = true, defaultValue = "0")
-  private int tripBikesAllowed = 0;
-
   /**
    * 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
    */
@@ -131,7 +127,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
     this.meanDurationOffset = obj.meanDurationOffset;
     this.safeDurationFactor = obj.safeDurationFactor;
     this.safeDurationOffset = obj.safeDurationOffset;
-    this.tripBikesAllowed = obj.tripBikesAllowed;
     this.bikesAllowed = obj.bikesAllowed;
     this.carsAllowed = obj.carsAllowed;
     this.fareId = obj.fareId;
@@ -243,16 +238,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
 
   public void setSafeDurationOffset(Double safeDurationOffset) {
     this.safeDurationOffset = safeDurationOffset;
-  }
-
-  @Deprecated
-  public void setTripBikesAllowed(int tripBikesAllowed) {
-    this.tripBikesAllowed = tripBikesAllowed;
-  }
-
-  @Deprecated
-  public int getTripBikesAllowed() {
-    return tripBikesAllowed;
   }
 
   /**

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
@@ -54,6 +54,12 @@ public final class Trip extends IdentityBean<AgencyAndId> {
   @CsvField(optional = true, defaultValue = "0")
   private int wheelchairAccessible = 0;
 
+  /**
+   * 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
+   */
+  @CsvField(optional = true, defaultValue = "0")
+  private int bikesAllowed = 0;
+
   @Experimental(proposedBy = "https://github.com/MobilityData/gtfs-flex/pull/79")
   @CsvField(optional = true)
   private Double meanDurationFactor;
@@ -69,13 +75,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
   @Experimental(proposedBy = "https://github.com/MobilityData/gtfs-flex/pull/79")
   @CsvField(optional = true)
   private Double safeDurationOffset;
-
-
-  /**
-   * 0 = unknown / unspecified, 1 = bikes allowed, 2 = bikes NOT allowed
-   */
-  @CsvField(optional = true, defaultValue = "0")
-  private int bikesAllowed = 0;
 
   /**
    * 0 = unknown / unspecified, 1 = cars allowed, 2 = cars NOT allowed

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Trip.java
@@ -43,9 +43,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
   private String tripHeadsign;
 
   @CsvField(optional = true)
-  private String routeShortName;
-
-  @CsvField(optional = true)
   private String directionId;
 
   @CsvField(optional = true)
@@ -56,27 +53,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
 
   @CsvField(optional = true, defaultValue = "0")
   private int wheelchairAccessible = 0;
-
-  @CsvField(optional = true)
-  private String drtMaxTravelTime;
-
-  @CsvField(optional = true)
-  private String drtAvgTravelTime;
-
-  @CsvField(optional = true, defaultValue = "-1")
-  private double drtAdvanceBookMin;
-
-  @CsvField(optional = true)
-  private String drtPickupMessage;
-
-  @CsvField(optional = true)
-  private String drtDropOffMessage;
-
-  @CsvField(optional = true)
-  private String continuousPickupMessage;
-
-  @CsvField(optional = true)
-  private String continuousDropOffMessage;
 
   @Experimental(proposedBy = "https://github.com/MobilityData/gtfs-flex/pull/79")
   @CsvField(optional = true)
@@ -147,18 +123,10 @@ public final class Trip extends IdentityBean<AgencyAndId> {
     this.serviceId = obj.serviceId;
     this.tripShortName = obj.tripShortName;
     this.tripHeadsign = obj.tripHeadsign;
-    this.routeShortName = obj.routeShortName;
     this.directionId = obj.directionId;
     this.blockId = obj.blockId;
     this.shapeId = obj.shapeId;
     this.wheelchairAccessible = obj.wheelchairAccessible;
-    this.drtMaxTravelTime = obj.drtMaxTravelTime;
-    this.drtAvgTravelTime = obj.drtAvgTravelTime;
-    this.drtAdvanceBookMin = obj.drtAdvanceBookMin;
-    this.drtPickupMessage = obj.drtPickupMessage;
-    this.drtDropOffMessage = obj.drtDropOffMessage;
-    this.continuousPickupMessage = obj.continuousPickupMessage;
-    this.continuousDropOffMessage = obj.continuousDropOffMessage;
     this.meanDurationFactor = obj.meanDurationFactor;
     this.meanDurationOffset = obj.meanDurationOffset;
     this.safeDurationFactor = obj.safeDurationFactor;
@@ -213,14 +181,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
     this.tripHeadsign = tripHeadsign;
   }
 
-  public String getRouteShortName() {
-    return routeShortName;
-  }
-
-  public void setRouteShortName(String routeShortName) {
-    this.routeShortName = routeShortName;
-  }
-
   public String getDirectionId() {
     return directionId;
   }
@@ -251,62 +211,6 @@ public final class Trip extends IdentityBean<AgencyAndId> {
 
   public int getWheelchairAccessible() {
     return wheelchairAccessible;
-  }
-
-  public String getDrtMaxTravelTime() {
-    return drtMaxTravelTime;
-  }
-
-  public void setDrtMaxTravelTime(String drtMaxTravelTime) {
-    this.drtMaxTravelTime = drtMaxTravelTime;
-  }
-
-  public String getDrtAvgTravelTime() {
-    return drtAvgTravelTime;
-  }
-
-  public void setDrtAvgTravelTime(String drtAvgTravelTime) {
-    this.drtAvgTravelTime = drtAvgTravelTime;
-  }
-
-  public double getDrtAdvanceBookMin() {
-    return drtAdvanceBookMin;
-  }
-
-  public void setDrtAdvanceBookMin(double drtAdvanceBookMin) {
-    this.drtAdvanceBookMin = drtAdvanceBookMin;
-  }
-
-  public String getDrtPickupMessage() {
-    return drtPickupMessage;
-  }
-
-  public void setDrtPickupMessage(String drtPickupMessage) {
-    this.drtPickupMessage = drtPickupMessage;
-  }
-
-  public String getDrtDropOffMessage() {
-    return drtDropOffMessage;
-  }
-
-  public void setDrtDropOffMessage(String drtDropOffMessage) {
-    this.drtDropOffMessage = drtDropOffMessage;
-  }
-
-  public String getContinuousPickupMessage() {
-    return continuousPickupMessage;
-  }
-
-  public void setContinuousPickupMessage(String continuousPickupMessage) {
-    this.continuousPickupMessage = continuousPickupMessage;
-  }
-
-  public String getContinuousDropOffMessage() {
-    return continuousDropOffMessage;
-  }
-
-  public void setContinuousDropOffMessage(String continuousDropOffMessage) {
-    this.continuousDropOffMessage = continuousDropOffMessage;
   }
 
   public Double getMeanDurationFactor() {

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -207,7 +207,6 @@ public class GtfsReaderTest extends BaseGtfsTest {
     assertEquals("1", trip.getDirectionId());
     assertEquals("B1", trip.getBlockId());
     assertEquals(new AgencyAndId("1", "SHP1"), trip.getShapeId());
-    assertEquals(1, trip.getTripBikesAllowed());
     assertEquals(2, trip.getBikesAllowed());
     assertEquals(1, trip.getCarsAllowed());
     assertEquals(1, trip.getWheelchairAccessible());

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -207,7 +207,6 @@ public class GtfsReaderTest extends BaseGtfsTest {
     assertEquals("1", trip.getDirectionId());
     assertEquals("B1", trip.getBlockId());
     assertEquals(new AgencyAndId("1", "SHP1"), trip.getShapeId());
-    assertEquals("10X", trip.getRouteShortName());
     assertEquals(1, trip.getTripBikesAllowed());
     assertEquals(2, trip.getBikesAllowed());
     assertEquals(1, trip.getCarsAllowed());


### PR DESCRIPTION
This removes many non-standard fields from trips.txt that are not part of the GTFS specification:

- routeShortName
- continuousDropOffMessage
- drtMaxTravelTime
- drtAdvanceBookMin
- drtDropOffMessage
- continuousPickupMessage
- continuousDropOffMessage

Heads up to @Heidebritta @jeffmaki @sheldonabrown These affect transformer strategies that you originally wrote.