### PR TITLE
Revert commons-cli update to fix transformer-cli

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,9 @@ changelog:
     - title: Breaking changes
       labels:
         - "Breaking change"
+    - title: Bugfixes
+      labels:
+        - bug
     - title: Dependency upgrades
       labels:
         - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,19 @@ jobs:
 
     - name: Test project with Maven
       run: mvn --no-transfer-progress test package
+
+  cli:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Run CLI e2e tests
+        run: ./cli-tests/cli-tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.releaseBackup
 /pom.xml.versionsBackup
 
 *.iml
+*.zip
+*.jar

--- a/cli-tests/cli-tests.sh
+++ b/cli-tests/cli-tests.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-mvn clean package -DskipTests -Dmaven.source.skip=true -Dmaven.javadoc.skip=true
+mvn clean package --no-transfer-progress -DskipTests -Dmaven.source.skip=true -Dmaven.javadoc.skip=true
 
 # transformer-cli
 
-cp onebusaway-gtfs-transformer-cli/target/onebusaway-gtfs-transformer-cli.jar ./transformer-cli.jar
+TRANSFORMER_JAR="transformer-cli.jar"
+
+cp onebusaway-gtfs-transformer-cli/target/onebusaway-gtfs-transformer-cli.jar ./${TRANSFORMER_JAR}
 wget https://github.com/google/transit/blob/master/gtfs/spec/en/examples/sample-feed-1.zip?raw=true -O gtfs.zip
 
-java -jar transformer-cli.jar --help
+java -jar ${TRANSFORMER_JAR} --help
 
-java -jar transformer-cli.jar --transform="{'op':'remove','match':{'file':'stops.txt','stop_id':'BEATTY_AIRPORT'}}" gtfs.zip gtfs.transformed.zip
+java -jar ${TRANSFORMER_JAR} --transform="{'op':'remove','match':{'file':'stops.txt','stop_id':'BEATTY_AIRPORT'}}" gtfs.zip gtfs.transformed.zip

--- a/cli-tests/cli-tests.sh
+++ b/cli-tests/cli-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mvn clean package -DskipTests -Dmaven.source.skip=true -Dmaven.javadoc.skip=true
+
+# transformer-cli
+
+cp onebusaway-gtfs-transformer-cli/target/onebusaway-gtfs-transformer-cli.jar ./transformer-cli.jar
+wget https://github.com/google/transit/blob/master/gtfs/spec/en/examples/sample-feed-1.zip?raw=true -O gtfs.zip
+
+java -jar transformer-cli.jar --help
+
+java -jar transformer-cli.jar --transform="{'op':'remove','match':{'file':'stops.txt','stop_id':'BEATTY_AIRPORT'}}" gtfs.zip gtfs.transformed.zip

--- a/onebusaway-gtfs-hibernate-cli/pom.xml
+++ b/onebusaway-gtfs-hibernate-cli/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.9.0</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/onebusaway-gtfs-merge-cli/pom.xml
+++ b/onebusaway-gtfs-merge-cli/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.9.0</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/onebusaway-gtfs-transformer-cli/pom.xml
+++ b/onebusaway-gtfs-transformer-cli/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.9.0</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
#287 has reported that the recent upgrade of commons-cli has broken the command line argument parsing of transformer-cli.

The CLI class has a lot of strange parsing in it that I cannot fix right away so I will revert the upgrade.

Closes #287