### PR TITLE
Build container images via jib-maven-plugin

### DIFF
--- a/onebusaway-collections/pom.xml
+++ b/onebusaway-collections/pom.xml
@@ -28,4 +28,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <!-- we don't want jib to execute on this module -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <!-- we want this library to be built reproducibly -->
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.11</version>
+        <executions>
+          <execution>
+            <id>run-when-packaged</id>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/onebusaway-csv-entities/pom.xml
+++ b/onebusaway-csv-entities/pom.xml
@@ -40,4 +40,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <!-- we don't want jib to execute on this module -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <!-- we want this library to be built reproducibly -->
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.11</version>
+        <executions>
+          <execution>
+            <id>run-when-packaged</id>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/onebusaway-gtfs-hibernate/pom.xml
+++ b/onebusaway-gtfs-hibernate/pom.xml
@@ -52,6 +52,33 @@
       <artifactId>jaxb-impl</artifactId>
       <scope>runtime</scope>
     </dependency>
-</dependencies>
+  </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <!-- we don't want jib to execute on this module -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <!-- we want this library to be built reproducibly -->
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.11</version>
+        <executions>
+          <execution>
+            <id>run-when-packaged</id>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/onebusaway-gtfs-merge/pom.xml
+++ b/onebusaway-gtfs-merge/pom.xml
@@ -37,4 +37,32 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <!-- we don't want jib to execute on this module -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <!-- we want this library to be built reproducibly -->
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.11</version>
+        <executions>
+          <execution>
+            <id>run-when-packaged</id>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/onebusaway-gtfs-transformer/pom.xml
+++ b/onebusaway-gtfs-transformer/pom.xml
@@ -79,4 +79,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <!-- we don't want jib to execute on this module -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <!-- we want this library to be built reproducibly -->
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.11</version>
+        <executions>
+          <execution>
+            <id>run-when-packaged</id>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/onebusaway-gtfs/pom.xml
+++ b/onebusaway-gtfs/pom.xml
@@ -49,4 +49,32 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <!-- we don't want jib to execute on this module -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <!-- we want this library to be built reproducibly -->
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.11</version>
+        <executions>
+          <execution>
+            <id>run-when-packaged</id>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,33 @@
           </statelessTestsetInfoReporter>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>3.4.4</version>
+        <configuration>
+            <from>
+                <image>eclipse-temurin:21-jre</image>
+                <platforms>
+                    <platform>
+                        <architecture>amd64</architecture>
+                        <os>linux</os>
+                    </platform>
+                    <platform>
+                        <architecture>arm64</architecture>
+                        <os>linux</os>
+                    </platform>
+                </platforms>
+            </from>
+            <to>
+                <image>${env.CONTAINER_REPO}/${project.artifactId}:${project.version}</image>
+                <auth>
+                    <username>${env.CONTAINER_REGISTRY_USER}</username>
+                    <password>${env.CONTAINER_REGISTRY_PASSWORD}</password>
+                </auth>
+            </to>
+        </configuration>
+      </plugin>
     </plugins>
 
     <pluginManagement>


### PR DESCRIPTION
**Summary:**

This PR adds `jib-maven-plugin` as build dependency which allows to build and publish onebusaway gtfs tools as docker images.

Note: currently, image names are build using their maven `artifactId` as repository names.
To build and publish them, an env variable `CONTAINER_REGISTRY_NAMESPACE` needs to be defined.

To build use e.g. `CONTAINER_REGISTRY_NAMESPACE=mfdz mvn jib:dockerBuild`, or, to build and publish to the registry `CONTAINER_REGISTRY_NAMESPACE=mfdz mvn jib:build`

It will build the following images (assuming current version is `4.0.1-SNAPSHOT`):

[mfdz/onebusaway-gtfs-merge-cli:4.0.1-SNAPSHOT](https://hub.docker.com/repository/docker/mfdz/onebusaway-gtfs-merge-cli/general)
[mfdz/onebusaway-gtfs-hibernate-cli:4.0.1-SNAPSHOT](https://hub.docker.com/repository/docker/mfdz/onebusaway-gtfs-hibernate-cli/general)
[mfdz/onebusaway-gtfs-transformer-cli:4.0.1-SNAPSHOT](https://hub.docker.com/repository/docker/mfdz/onebusaway-gtfs-transformer-cli/general)

According to `jib-maven-plugin multi-module example`, module-dependencies are built as [reproducible builds](https://github.com/GoogleContainerTools/jib/tree/master/examples/multi-module#reproducibility-of-dependency-module-shared-library).