### PR TITLE
Add networks.txt model

### DIFF
--- a/onebusaway-gtfs-hibernate/src/main/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.java
+++ b/onebusaway-gtfs-hibernate/src/main/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.java
@@ -343,6 +343,10 @@ public class HibernateGtfsRelationalDaoImpl implements GtfsMutableRelationalDao 
   public Collection<Translation> getAllTranslations() {
     return _ops.find("FROM Translation");
   }
+
+  @Override
+  public Collection<Network> getAllNetworks() {
+    return _ops.find("FROM Network");
   }
 
   @Override

--- a/onebusaway-gtfs-hibernate/src/main/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.java
+++ b/onebusaway-gtfs-hibernate/src/main/java/org/onebusaway/gtfs/impl/HibernateGtfsRelationalDaoImpl.java
@@ -70,12 +70,12 @@ public class HibernateGtfsRelationalDaoImpl implements GtfsMutableRelationalDao 
 
   @Override
   public List<Agency> getAllAgencies() {
-    return _ops.find("from Agency");
+    return _ops.find("FROM Agency");
   }
 
   @Override
   public List<Block> getAllBlocks() {
-    return _ops.find("from Block");
+    return _ops.find("FROM Block");
   }
   
   @Override
@@ -294,7 +294,7 @@ public class HibernateGtfsRelationalDaoImpl implements GtfsMutableRelationalDao 
 
   @Override
   public Collection<Area> getAllAreas() {
-    return _ops.find("from Area");
+    return _ops.find("FROM Area");
   }
 
   @Deprecated
@@ -327,7 +327,7 @@ public class HibernateGtfsRelationalDaoImpl implements GtfsMutableRelationalDao 
   }
   @Override
   public Collection<StopArea> getAllStopAreas() {
-    return _ops.find("from StopArea");
+    return _ops.find("FROM StopArea");
   }
   @Override
   public Collection<Location> getAllLocations() {
@@ -336,12 +336,13 @@ public class HibernateGtfsRelationalDaoImpl implements GtfsMutableRelationalDao 
 
   @Override
   public Collection<BookingRule> getAllBookingRules() {
-    return _ops.find("from BookingRule");
+    return _ops.find("FROM BookingRule");
   }
 
   @Override
   public Collection<Translation> getAllTranslations() {
-    return _ops.find("from Translation");
+    return _ops.find("FROM Translation");
+  }
   }
 
   @Override

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
@@ -259,6 +259,9 @@ public class GtfsDaoImpl extends GenericDaoImpl implements GtfsMutableDao {
     return getEntityForId(Vehicle.class, id);
   }
 
+  public Collection<Network> getAllNetworks() {
+    return getAllEntitiesForType(Network.class);
+  }
 
 
   public Facility getFacilityForId(AgencyAndId id) { return getEntityForId(Facility.class, id);}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
@@ -146,7 +146,9 @@ public class GtfsDaoImpl extends GenericDaoImpl implements GtfsMutableDao {
     return getAllEntitiesForType(Ridership.class);
   }
 
-  public Collection<Vehicle> getAllVehicles() { return getAllEntitiesForType(Vehicle.class); }
+  public Collection<Vehicle> getAllVehicles() {
+    return getAllEntitiesForType(Vehicle.class);
+  }
 
   public Collection<Level> getAllLevels() {
     return getAllEntitiesForType(Level.class);

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
@@ -404,6 +404,11 @@ public class GtfsDataServiceImpl implements GtfsDataService {
     }
 
     @Override
+    public Collection<Network> getAllNetworks() {
+        return _dao.getAllNetworks();
+    }
+
+    @Override
     public List<String> getOptionalMetadataFilenames() {
         return _dao.getOptionalMetadataFilenames();
     }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Network.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Network.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2024 Sound Transit <GTFSTeam@soundtransit.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs.model;
+
+import org.onebusaway.csv_entities.schema.annotations.CsvField;
+import org.onebusaway.csv_entities.schema.annotations.CsvFields;
+import org.onebusaway.gtfs.serialization.mappings.DefaultAgencyIdFieldMappingFactory;
+
+@CsvFields(filename = "networks.txt", required = false)
+public final class Network extends IdentityBean<AgencyAndId> {
+
+    private static final long serialVersionUID = 1L;
+
+    @CsvField(name = "network_id", mapping = DefaultAgencyIdFieldMappingFactory.class)
+    private AgencyAndId id;
+
+    @CsvField(name = "network_name", optional = true)
+    private String name;
+
+    @Override
+    public AgencyAndId getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(AgencyAndId id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "<Network " + this.id + ">";
+    }
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
@@ -76,6 +76,7 @@ public class GtfsEntitySchemaFactory {
     entityClasses.add(DirectionEntry.class);
     entityClasses.add(AlternateStopNameException.class);
     entityClasses.add(Icon.class);
+    entityClasses.add(Network.class);
     return entityClasses;
   }
 

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
@@ -104,6 +104,7 @@ public class GtfsReader extends CsvEntityReader {
     _entityClasses.add(WrongWayConcurrency.class);
     _entityClasses.add(DirectionEntry.class);
     _entityClasses.add(AlternateStopNameException.class);
+    _entityClasses.add(Network.class);
 
     CsvTokenizerStrategy tokenizerStrategy = new CsvTokenizerStrategy();
     tokenizerStrategy.getCsvParser().setTrimInitialWhitespace(true);

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/services/GtfsDao.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/services/GtfsDao.java
@@ -220,6 +220,12 @@ public interface GtfsDao extends GenericDao {
 
   public Collection<Translation> getAllTranslations();
 
+    /****
+   * {@link Network} Methods
+   ****/
+
+   public Collection<Network> getAllNetworks();
+
   public Collection<DirectionEntry> getAllDirectionEntries();
 
   public Collection<WrongWayConcurrency> getAllWrongWayConcurrencies();

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/NetworkTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/NetworkTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2024 Sound Transit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.serialization.GtfsWriter;
+import org.onebusaway.gtfs.serialization.GtfsWriterTest;
+import org.onebusaway.gtfs.services.MockGtfs;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+
+import static  org.junit.jupiter.api.Assertions.*;
+
+public class NetworkTest {
+
+    private MockGtfs _gtfs;
+
+    private File _tmpDirectory;
+
+    @BeforeEach
+    public void before() throws IOException {
+        _gtfs = MockGtfs.create();
+
+        //make temp directory for gtfs writing output
+        _tmpDirectory = File.createTempFile("NetworkTest-", "-tmp");
+        if (_tmpDirectory.exists())
+            GtfsWriterTest.deleteFileRecursively(_tmpDirectory);
+        _tmpDirectory.mkdirs();
+    }
+
+    @Test
+    public void testBasicNetworks() throws IOException {
+        _gtfs.putMinimal();
+        _gtfs.putDefaultTrips();
+        _gtfs.putDefaultStops();
+        _gtfs.putLines("networks.txt",
+                "network_id,network_name",
+                "rail_network,Rail Network", "bus_network,Bus Network");
+
+        GtfsRelationalDao dao = _gtfs.read();
+        assertEquals(2, dao.getAllNetworks().size());
+
+        GtfsWriter writer = new GtfsWriter();
+        writer.setOutputLocation(_tmpDirectory);
+        writer.run(dao);
+
+        Scanner scan = new Scanner(new File(_tmpDirectory + "/networks.txt"));
+        Set<String> expectedNetworkNames = new HashSet<String>();
+        Set<String> foundNetworkNames = new HashSet<String>();
+        expectedNetworkNames.add("Rail Network");
+        expectedNetworkNames.add("Bus Network");
+        boolean onHeader = true;
+        while(scan.hasNext()){
+            String line = scan.nextLine();
+            if (onHeader) {
+                onHeader = false;
+            } else {
+                String[] lineParts = line.split(",");
+
+                if (lineParts.length > 1) {
+                    foundNetworkNames.add(lineParts[1]);
+                }
+            }
+        }
+        scan.close();
+
+        assertEquals(expectedNetworkNames, foundNetworkNames, "Did not find network names in output");
+    }
+
+    @Test
+    public void testPutMinimal() throws IOException {
+        _gtfs.putMinimal();
+        // Just make sure it parses without throwing an error.
+        _gtfs.read();
+    }
+
+    @AfterEach
+    public void teardown() {
+        deleteFileRecursively(_tmpDirectory);
+    }
+
+    public static void deleteFileRecursively(File file) {
+
+        if (!file.exists())
+            return;
+
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File child : files)
+                    deleteFileRecursively(child);
+            }
+        }
+
+        file.delete();
+    }
+
+}
+


### PR DESCRIPTION
**Summary:**

Adds the Network model for networks.txt used in Fares v2.

**Expected behavior:** 

Allows reading and writing to networks.txt with network_id and network_name.

Tested in NetworkTest.java.
