### PR TITLE
Format currency amounts in fare_products.txt with 2 decimal digits

### DIFF
--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/schema/DecimalFieldMappingFactory.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/schema/DecimalFieldMappingFactory.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
+import java.util.Currency;
 import java.util.Locale;
 import java.util.Map;
 
@@ -37,6 +38,8 @@ public class DecimalFieldMappingFactory implements FieldMappingFactory {
 
   private Locale _locale = Locale.US;
 
+  private Currency _currency;
+
   public DecimalFieldMappingFactory() {
 
   }
@@ -48,6 +51,10 @@ public class DecimalFieldMappingFactory implements FieldMappingFactory {
   public DecimalFieldMappingFactory(String format, Locale locale) {
     _format = format;
     _locale = locale;
+  }
+
+  public DecimalFieldMappingFactory(Currency currency) {
+    _currency = currency;
   }
 
   @Override
@@ -63,7 +70,11 @@ public class DecimalFieldMappingFactory implements FieldMappingFactory {
 
   private NumberFormat getFormat(Class<?> entityType, String objFieldName) {
     String format = determineFormat(entityType, objFieldName);
-    if (_locale == null) {
+    if (_currency != null) {
+      NumberFormat currFormatter = NumberFormat.getCurrencyInstance(Locale.US);
+      currFormatter.setCurrency(_currency);
+      return currFormatter;
+    } else if (_locale == null) {
       return new DecimalFormat(format);
     } else {
       return new DecimalFormat(format, new DecimalFormatSymbols(_locale));

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareProduct.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareProduct.java
@@ -21,6 +21,7 @@ import org.onebusaway.csv_entities.schema.annotations.CsvFields;
 import org.onebusaway.gtfs.serialization.mappings.DefaultAgencyIdFieldMappingFactory;
 import org.onebusaway.gtfs.serialization.mappings.EntityFieldMappingFactory;
 import org.onebusaway.gtfs.serialization.mappings.FareProductFieldMappingFactory;
+import org.onebusaway.gtfs.serialization.mappings.FareAmountFieldMappingFactory;
 
 @CsvFields(filename = "fare_products.txt", required = false)
 public final class FareProduct extends IdentityBean<AgencyAndId> {
@@ -32,7 +33,7 @@ public final class FareProduct extends IdentityBean<AgencyAndId> {
   private AgencyAndId fareProductId;
   @CsvField(optional = true, name = "fare_product_name")
   private String name;
-  @CsvField
+  @CsvField(name = "amount", optional = false, mapping = FareAmountFieldMappingFactory.class)
   private float amount = MISSING_VALUE;
   @CsvField
   private String currency;

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactory.java
@@ -76,7 +76,7 @@ public class FareAmountFieldMappingFactory implements FieldMappingFactory {
   
         Object value = csvValues.get(_csvFieldName);
 
-        Float amount = (float) value;
+        Float amount = Float.parseFloat(value.toString());
         object.setPropertyValue(_objFieldName, amount);
     }
   }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactory.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2024 Sound Transit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs.serialization.mappings;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Currency;
+import java.util.Locale;
+import java.util.Map;
+
+import org.onebusaway.csv_entities.CsvEntityContext;
+import org.onebusaway.csv_entities.exceptions.CsvEntityException;
+import org.onebusaway.csv_entities.schema.AbstractFieldMapping;
+import org.onebusaway.csv_entities.schema.BeanWrapper;
+import org.onebusaway.csv_entities.schema.EntitySchemaFactory;
+import org.onebusaway.csv_entities.schema.FieldMapping;
+import org.onebusaway.csv_entities.schema.FieldMappingFactory;
+
+public class FareAmountFieldMappingFactory implements FieldMappingFactory {
+  
+
+  public FieldMapping createFieldMapping(EntitySchemaFactory schemaFactory,
+      Class<?> entityType, String csvFieldName, String objFieldName,
+      Class<?> objFieldType, boolean required) {
+
+    return new FareAmountFieldMapping(entityType, csvFieldName, objFieldName, required);
+  }
+  
+  private static class FareAmountFieldMapping extends AbstractFieldMapping {
+
+    public FareAmountFieldMapping(Class<?> entityType, String csvFieldName,
+                                   String objFieldName, boolean required) {
+      super(entityType, csvFieldName, objFieldName, required);
+    }
+
+    @Override
+    public void translateFromObjectToCSV(CsvEntityContext context,
+        BeanWrapper object, Map<String, Object> csvValues) {
+
+        String currencyString = (String) object.getPropertyValue("currency");
+        Currency currency = Currency.getInstance(currencyString);
+        Float amount = (Float) object.getPropertyValue(_objFieldName);
+
+        DecimalFormat formatter = (DecimalFormat) NumberFormat.getCurrencyInstance(Locale.US);
+        formatter.setCurrency(currency);
+
+        // remove "$", "¥", "₹" and other currency symbols from the output
+        DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
+        symbols.setCurrencySymbol("");
+        formatter.setDecimalFormatSymbols(symbols);
+        formatter.setMaximumFractionDigits(currency.getDefaultFractionDigits());
+
+        csvValues.put(_csvFieldName, formatter.format(amount));
+    }
+
+    @Override
+    public void translateFromCSVToObject(CsvEntityContext context, Map<String, Object> csvValues, BeanWrapper object)
+        throws CsvEntityException {
+
+        if (isMissingAndOptional(csvValues))
+          return;
+  
+        Object value = csvValues.get(_csvFieldName);
+
+        Float amount = (float) value;
+        object.setPropertyValue(_objFieldName, amount);
+    }
+  }
+}

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FareProductWriterTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FareProductWriterTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2024 Sound Transit <GTFSTeam@soundtransit.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.onebusaway.gtfs.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.impl.FileSupport;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.FareProduct;
+
+public class FareProductWriterTest {
+      private FileSupport _support = new FileSupport();
+  private File _tmpDirectory;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    _tmpDirectory = File.createTempFile("FareProductWriterTest-", "-tmp");
+    if (_tmpDirectory.exists())
+      _support.deleteFileRecursively(_tmpDirectory);
+    _tmpDirectory.mkdirs();
+    _support.markForDeletion(_tmpDirectory);
+  }
+
+  @AfterEach
+  public void teardown() {
+    _support.cleanup();
+  }
+
+  @Test
+  public void testWriteAmountWithCorrectDecimalPlaces() throws IOException {
+
+    GtfsWriter writer = new GtfsWriter();
+    writer.setOutputLocation(_tmpDirectory);
+
+    FareProduct fp = new FareProduct();
+    String agencyId = "a1";
+    String fareProductId = "fp1";
+    AgencyAndId fpAgencyAndId = new AgencyAndId(agencyId, fareProductId);
+    float floatCurrency = 4.7f;
+    String formattedCurrency = "4.70";
+
+    fp.setId(fpAgencyAndId);
+    fp.setFareProductId(fpAgencyAndId);
+    fp.setCurrency("USD");
+    fp.setAmount(floatCurrency);
+
+    writer.handleEntity(fp);
+
+    writer.close();
+
+    GtfsReader reader = new GtfsReader();
+    reader.setDefaultAgencyId(agencyId);
+    reader.setInputLocation(_tmpDirectory);
+
+    Scanner scan = new Scanner(new File(_tmpDirectory + "/fare_products.txt"));
+
+    Boolean onHeader = true;
+    Boolean containsExpected = false;
+    while(scan.hasNext()){
+        String line = scan.nextLine();
+        if (onHeader) {
+            onHeader = false;
+        } else {
+            if (line.contains(formattedCurrency)) {
+                containsExpected = true;
+            }
+        }
+    }
+    scan.close();
+
+    assertTrue(containsExpected, "Line in fare_products.txt did not contain formatted currency amount 4.70");
+
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+    reader.setEntityStore(dao);
+
+    reader.readEntities(FareProduct.class);
+
+    FareProduct fareProductFromFile = dao.getAllFareProducts().iterator().next();
+
+    assertEquals(fareProductFromFile.getAmount(), floatCurrency);
+  }
+
+  public static void deleteFileRecursively(File file) {
+
+    if (!file.exists())
+      return;
+
+    if (file.isDirectory()) {
+      File[] files = file.listFiles();
+      if (files != null) {
+        for (File child : files)
+          deleteFileRecursively(child);
+      }
+    }
+
+    file.delete();
+  }
+}

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FareProductWriterTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FareProductWriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2024 Sound Transit <GTFSTeam@soundtransit.org>
+ * Copyright (C) 2025 Sound Transit <GTFSTeam@soundtransit.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactoryTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactoryTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.onebusaway.csv_entities.CsvEntityContextImpl;
 import org.onebusaway.csv_entities.schema.BeanWrapperFactory;
 import org.onebusaway.csv_entities.schema.DefaultEntitySchemaFactory;
-import org.onebusaway.csv_entities.schema.DefaultFieldMapping;
 import org.onebusaway.csv_entities.schema.FieldMapping;
 import org.onebusaway.gtfs.model.FareProduct;
 import org.onebusaway.gtfs.serialization.GtfsEntitySchemaFactory;
@@ -42,11 +41,41 @@ public class FareAmountFieldMappingFactoryTest {
   @Test
   public void testTranslateFromCSVToObject() {
     Map<String, Object> csvValues = new HashMap<String, Object>();
-    csvValues.put("amount", 47.1234f);
+    csvValues.put("amount", "47.12");
     csvValues.put("currency", "USD");
     FareProduct fp = new FareProduct();
     _fieldMapping.translateFromCSVToObject(new CsvEntityContextImpl(), csvValues, BeanWrapperFactory.wrap(fp));
-    assertEquals(47.1234, fp.getAmount(), 0.00001);
+    assertEquals(47.12, fp.getAmount(), 0.001);
+  }
+
+  @Test
+  public void testTranslateFromCSVToObjectWhole() {
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+    csvValues.put("amount", "47");
+    csvValues.put("currency", "USD");
+    FareProduct fp = new FareProduct();
+    _fieldMapping.translateFromCSVToObject(new CsvEntityContextImpl(), csvValues, BeanWrapperFactory.wrap(fp));
+    assertEquals(47, fp.getAmount(), 0.001);
+  }
+
+  @Test
+  public void testTranslateFromCSVToObjectWholeDecimals() {
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+    csvValues.put("amount", "47.00");
+    csvValues.put("currency", "USD");
+    FareProduct fp = new FareProduct();
+    _fieldMapping.translateFromCSVToObject(new CsvEntityContextImpl(), csvValues, BeanWrapperFactory.wrap(fp));
+    assertEquals(47, fp.getAmount(), 0.001);
+  }
+
+  @Test
+  public void testTranslateFromCSVToObjectNonUSD() {
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+    csvValues.put("amount", "47");
+    csvValues.put("currency", "JPY");
+    FareProduct fp = new FareProduct();
+    _fieldMapping.translateFromCSVToObject(new CsvEntityContextImpl(), csvValues, BeanWrapperFactory.wrap(fp));
+    assertEquals(47, fp.getAmount(), 0.001);
   }
 
   @Test

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactoryTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/mappings/FareAmountFieldMappingFactoryTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2024 Sound Transit
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs.serialization.mappings;
+
+import static  org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.onebusaway.csv_entities.CsvEntityContextImpl;
+import org.onebusaway.csv_entities.schema.BeanWrapperFactory;
+import org.onebusaway.csv_entities.schema.DefaultEntitySchemaFactory;
+import org.onebusaway.csv_entities.schema.DefaultFieldMapping;
+import org.onebusaway.csv_entities.schema.FieldMapping;
+import org.onebusaway.gtfs.model.FareProduct;
+import org.onebusaway.gtfs.serialization.GtfsEntitySchemaFactory;
+
+public class FareAmountFieldMappingFactoryTest {
+
+  private FieldMapping _fieldMapping;
+
+  @BeforeEach
+  public void before() {
+    _fieldMapping = buildFieldMapping();
+  }
+
+  @Test
+  public void testTranslateFromCSVToObject() {
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+    csvValues.put("amount", 47.1234f);
+    csvValues.put("currency", "USD");
+    FareProduct fp = new FareProduct();
+    _fieldMapping.translateFromCSVToObject(new CsvEntityContextImpl(), csvValues, BeanWrapperFactory.wrap(fp));
+    assertEquals(47.1234, fp.getAmount(), 0.00001);
+  }
+
+  @Test
+  public void testTranslateFromObjectToCSV() {
+    FareProduct fp = new FareProduct();
+    fp.setAmount(4.7f);
+    fp.setCurrency("USD");
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+
+    _fieldMapping.translateFromObjectToCSV(new CsvEntityContextImpl(), BeanWrapperFactory.wrap(fp), csvValues);
+    assertEquals("4.70", csvValues.get("amount"));
+  }
+
+  @Test
+  public void testTranslateFromObjectToCSVCents() {
+    FareProduct fp = new FareProduct();
+    fp.setAmount(4.75f);
+    fp.setCurrency("USD");
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+
+    _fieldMapping.translateFromObjectToCSV(new CsvEntityContextImpl(), BeanWrapperFactory.wrap(fp), csvValues);
+    assertEquals("4.75", csvValues.get("amount"));
+  }
+
+  @Test
+  public void testTranslateFromObjectToCSVCentsAndMore() {
+    FareProduct fp = new FareProduct();
+    fp.setAmount(4.123f);
+    fp.setCurrency("USD");
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+
+    _fieldMapping.translateFromObjectToCSV(new CsvEntityContextImpl(), BeanWrapperFactory.wrap(fp), csvValues);
+    assertEquals("4.12", csvValues.get("amount"));
+  }
+
+  @Test
+  public void testTranslateFromObjectToCSVNonUSD() {
+    FareProduct fp = new FareProduct();
+    fp.setAmount(0.7f);
+    fp.setCurrency("EUR");
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+
+    _fieldMapping.translateFromObjectToCSV(new CsvEntityContextImpl(), BeanWrapperFactory.wrap(fp), csvValues);
+    assertEquals("0.70", csvValues.get("amount"));
+  }
+
+  @Test
+  public void testTranslateFromObjectToCSVWhole() {
+    FareProduct fp = new FareProduct();
+    fp.setAmount(4f);
+    fp.setCurrency("USD");
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+
+    _fieldMapping.translateFromObjectToCSV(new CsvEntityContextImpl(), BeanWrapperFactory.wrap(fp), csvValues);
+    assertEquals("4.00", csvValues.get("amount"));
+  }
+
+  @Test
+  public void testTranslateFromObjectToCSVNoDecimal() {
+    FareProduct fp = new FareProduct();
+    fp.setAmount(4f);
+    fp.setCurrency("VND");
+    Map<String, Object> csvValues = new HashMap<String, Object>();
+
+    _fieldMapping.translateFromObjectToCSV(new CsvEntityContextImpl(), BeanWrapperFactory.wrap(fp), csvValues);
+    assertEquals("4", csvValues.get("amount"));
+
+    fp.setAmount(5.2f);
+    _fieldMapping.translateFromObjectToCSV(new CsvEntityContextImpl(), BeanWrapperFactory.wrap(fp), csvValues);
+    assertEquals("5", csvValues.get("amount"), "Amount did not get rounded to nearest whole number for currency that doesn't use decimals");
+  }
+
+  private FieldMapping buildFieldMapping() {
+    FareAmountFieldMappingFactory factory = new FareAmountFieldMappingFactory();
+    DefaultEntitySchemaFactory schemaFactory = GtfsEntitySchemaFactory.createEntitySchemaFactory();
+    return factory.createFieldMapping(schemaFactory, FareProduct.class, "amount",
+        "amount", Float.TYPE, true);
+  }
+}


### PR DESCRIPTION
**Summary:**

Currently, these modules will incorrectly convert FareProduct amounts to output with an incorrect number of decimal places. For example, "2.50" will be converted to "2.5" when using the transformer or merger CLI. This results in the validation error https://gtfs-validator.mobilitydata.org/rules.html#invalid_currency_amount-rule.

This PR fixes the issue by treating the value as a Java Currency object, then using the CurrencyInstance of DecimalFormatter (stripped of the currency symbol) that produces a string format with the correct number of decimal places based on the currency.

**Expected behavior:** 

* Tests in FareAmountFieldMappingFactoryTest will pass
* Output to the `amount` field in fare_products.txt will include 0 or 2 decimal places, depending on currency specified. It will "correct" the input as long as it can successfully parse as a decimal number.
* Datasets processed with onebusaway-gtfs-transformer-cli, onebusaway-gtfs-merge-cli, or other tools that use onebusaway-gtfs will no longer generate output that results in the https://gtfs-validator.mobilitydata.org/rules.html#invalid_currency_amount-rule ERROR.
