### PR TITLE
Remove non-standard fields from stop_times.txt

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripsForSdon.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/UpdateTripsForSdon.java
@@ -143,7 +143,6 @@ public class UpdateTripsForSdon implements GtfsTransformStrategy {
                         st.setDepartureTime(stopTime.getDepartureTime());
                         st.setStopSequence(stopTime.getStopSequence());
                         st.setDropOffType(stopTime.getDropOffType());
-                        st.setDepartureBuffer(stopTime.getDepartureBuffer());
                         dao.saveOrUpdateEntity(st);
 
                         countdao++;

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/StopTimeArray.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/StopTimeArray.java
@@ -85,8 +85,6 @@ public class StopTimeArray extends AbstractList<StopTime> {
     size++;
     ensureCapacity(size);
     trips[index] = stopTime.getTrip();
-    startServiceAreas[index] = stopTime.getStartServiceArea();
-    endServiceAreas[index] = stopTime.getEndServiceArea();
     stops[index] = stopTime.getStop();
     locations[index] = stopTime.getLocation();
     locationGroups[index] = stopTime.getLocationGroup();
@@ -105,7 +103,6 @@ public class StopTimeArray extends AbstractList<StopTime> {
     safeFactors[index] = stopTime.getSafeDurationFactor();
     meanOffsets[index] = stopTime.getMeanDurationOffset();
     meanFactors[index] = stopTime.getMeanDurationFactor();
-    freeRunningFlags[index] = stopTime.getFreeRunningFlag();
 
     return true;
   }
@@ -224,26 +221,6 @@ public class StopTimeArray extends AbstractList<StopTime> {
     @Override
     public void setTrip(Trip trip) {
       trips[index] = trip;
-    }
-
-    @Override
-    public Area getStartServiceArea() {
-      return startServiceAreas[index];
-    }
-
-    @Override
-    public void setStartServiceArea(Area area) {
-      startServiceAreas[index] = area;
-    }
-
-    @Override
-    public Area getEndServiceArea() {
-      return endServiceAreas[index];
-    }
-
-    @Override
-    public void setEndServiceArea(Area area) {
-      endServiceAreas[index] = area;
     }
 
     @Override
@@ -466,14 +443,5 @@ public class StopTimeArray extends AbstractList<StopTime> {
       safeOffsets[index] = safeDurationOffset;
     }
 
-    @Override
-    public String getFreeRunningFlag() {
-      return freeRunningFlags[index];
-    }
-
-    @Override
-    public void setFreeRunningFlag(String freeRunningFlag) {
-      freeRunningFlags[index] = freeRunningFlag;
-    }
   }
 }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -28,8 +28,6 @@ import org.slf4j.LoggerFactory;
 public final class StopTime extends IdentityBean<Integer> implements
     Comparable<StopTime>, StopTimeProxy {
 
-  private static Logger _log = LoggerFactory.getLogger(StopTime.class);
-
   private static final long serialVersionUID =2L;
 
   public static final int MISSING_VALUE = -999;
@@ -96,18 +94,6 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, defaultValue = "1")
   private int continuousDropOff = MISSING_FLEX_VALUE;
 
-  @CsvField(optional = true, name = "start_service_area_id", mapping = EntityFieldMappingFactory.class, order = -2)
-  private Area startServiceArea;
-
-  @CsvField(optional = true, name = "end_service_area_id", mapping = EntityFieldMappingFactory.class, order = -2)
-  private Area endServiceArea;
-
-  @CsvField(optional = true, defaultValue = "-999.0")/*note defaultValue quirk for non-proxied comparison*/
-  private double startServiceAreaRadius = MISSING_VALUE;
-
-  @CsvField(optional = true, defaultValue = "-999.0")/*note defaultValue quirk for non-proxied comparison*/
-  private double endServiceAreaRadius = MISSING_VALUE;
-
   @CsvField(ignore = true)
   private transient StopTimeProxy proxy = null;
 
@@ -117,22 +103,6 @@ public final class StopTime extends IdentityBean<Integer> implements
 
   @CsvField(optional = true, name = "drop_off_booking_rule_id", mapping = EntityFieldMappingFactory.class, order = -2)
   private BookingRule dropOffBookingRule;
-
-  /** This is a Conveyal extension to the GTFS spec to support Seattle on/off peak fares. */
-  @CsvField(optional = true)
-  private String farePeriodId;
-
-  /** Extension to support departure buffer https://groups.google.com/forum/#!msg/gtfs-changes/sHTyliLgMQk/gfpaGkI_AgAJ */
-  @CsvField(optional = true, defaultValue = "-999")
-  private int departureBuffer;
-
-  /** Support track extension */
-  @CsvField(optional = true)
-  private String track;
-
-  // Custom extension for MNR
-  @CsvField(optional = true, name = "note_id", mapping = EntityFieldMappingFactory.class, order = -1)
-  private Note note;
 
   // See https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md
   @CsvField(optional = true, name = "mean_duration_factor", defaultValue = "-999.0")/*note defaultValue quirk for non-proxied comparison*/
@@ -147,9 +117,6 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, name = "safe_duration_offset", defaultValue = "-999.0")
   private double safeDurationOffset = MISSING_VALUE;
 
-  @CsvField(optional = true, name = "free_running_flag")
-  private String freeRunningFlag;
-  
   public StopTime() {
 
   }
@@ -166,7 +133,6 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.continuousDropOff = st.continuousDropOff;
     this.routeShortName = st.routeShortName;
     this.shapeDistTraveled = st.shapeDistTraveled;
-    this.farePeriodId = st.farePeriodId;
     this.stop = st.stop;
     this.location = st.location;
     this.locationGroup = st.locationGroup;
@@ -175,20 +141,12 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.toStopSequence = st.toStopSequence;
     this.timepoint = st.timepoint;
     this.trip = st.trip;
-    this.startServiceArea = st.startServiceArea;
-    this.endServiceArea = st.endServiceArea;
-    this.startServiceAreaRadius = st.startServiceAreaRadius;
-    this.endServiceAreaRadius = st.endServiceAreaRadius;
-    this.departureBuffer = st.departureBuffer;
-    this.track = st.track;
-    this.note = st.note;
     this.pickupBookingRule = st.pickupBookingRule;
     this.dropOffBookingRule = st.dropOffBookingRule;
     this.safeDurationFactor= st.safeDurationFactor;
     this.safeDurationOffset= st.safeDurationOffset;
     this.meanDurationOffset= st.meanDurationOffset;
     this.meanDurationFactor= st.meanDurationFactor;
-    this.freeRunningFlag = st.freeRunningFlag;
   }
 
   public Integer getId() {
@@ -536,85 +494,6 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.shapeDistTraveled = MISSING_VALUE;
   }
 
-  public String getFarePeriodId() {
-    return farePeriodId;
-  }
-
-  public void setFarePeriodId(String farePeriodId) {
-    this.farePeriodId = farePeriodId;
-  }
-
-  public Area getStartServiceArea() {
-    if (proxy != null) {
-      return proxy.getStartServiceArea();
-    }
-    return startServiceArea;
-  }
-
-  public void setStartServiceArea(Area startServiceArea) {
-    if (proxy != null) {
-      proxy.setStartServiceArea(startServiceArea);
-      return;
-    }
-    this.startServiceArea = startServiceArea;
-  }
-
-  public Area getEndServiceArea() {
-    if (proxy != null) {
-      return proxy.getEndServiceArea();
-    }
-    return endServiceArea;
-  }
-
-
-  public void setEndServiceArea(Area endServiceArea) {
-    if (proxy != null) {
-      proxy.setEndServiceArea(endServiceArea);
-      return;
-    }
-    this.endServiceArea = endServiceArea;
-  }
-
-  public double getStartServiceAreaRadius() {
-    return startServiceAreaRadius;
-  }
-
-  public void setStartServiceAreaRadius(double startServiceAreaRadius) {
-    this.startServiceAreaRadius = startServiceAreaRadius;
-  }
-
-  public double getEndServiceAreaRadius() {
-    return endServiceAreaRadius;
-  }
-
-  public void setEndServiceAreaRadius(double endServiceAreaRadius) {
-    this.endServiceAreaRadius = endServiceAreaRadius;
-  }
-
-  public int getDepartureBuffer() {
-    return departureBuffer;
-  }
-
-  public void setDepartureBuffer(int departureBuffer) {
-    this.departureBuffer = departureBuffer;
-  }
-
-  public String getTrack() {
-    return track;
-  }
-
-  public void setTrack(String track) {
-    this.track = track;
-  }
-
-  public Note getNote() {
-    return note;
-  }
-
-  public void setNote(Note note) {
-    this.note = note;
-  }
-
   public int compareTo(StopTime o) {
     return this.getStopSequence() - o.getStopSequence();
   }
@@ -724,20 +603,5 @@ public final class StopTime extends IdentityBean<Integer> implements
 	      }
 	    this.safeDurationOffset = safeDurationOffset;
 	}
-
-  public String getFreeRunningFlag() {
-    if (proxy != null) {
-      return proxy.getFreeRunningFlag();
-    }
-    return freeRunningFlag;
-  }
-
-  public void setFreeRunningFlag(String freeRunningFlag) {
-    if (proxy != null) {
-      proxy.setFreeRunningFlag(freeRunningFlag);
-      return;
-    }
-    this.freeRunningFlag = freeRunningFlag;
-  }
 
 }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTimeProxy.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTimeProxy.java
@@ -23,111 +23,99 @@ package org.onebusaway.gtfs.model;
  */
 public interface StopTimeProxy {
 
-  public Integer getId();
+  Integer getId();
 
-  public void setId(Integer id);
+  void setId(Integer id);
 
-  public Trip getTrip();
+  Trip getTrip();
 
-  public Area getStartServiceArea();
+  void setTrip(Trip trip);
 
-  public void setStartServiceArea(Area area);
+  int getStopSequence();
 
-  public Area getEndServiceArea();
+  void setStopSequence(int stopSequence);
 
-  public void setEndServiceArea(Area area);
+  StopLocation getStop();
 
-  public void setTrip(Trip trip);
+  StopLocation getLocation();
+  StopLocation getLocationGroup();
 
-  public int getStopSequence();
+  void setStop(StopLocation stop);
 
-  public void setStopSequence(int stopSequence);
+  void setLocation(StopLocation stop);
 
-  public StopLocation getStop();
+  void setLocationGroup(StopLocation stop);
 
-  public StopLocation getLocation();
-  public StopLocation getLocationGroup();
+  boolean isArrivalTimeSet();
 
-  public void setStop(StopLocation stop);
+  int getArrivalTime();
 
-  public void setLocation(StopLocation stop);
+  void setArrivalTime(int arrivalTime);
 
-  public void setLocationGroup(StopLocation stop);
+  void clearArrivalTime();
 
-  public boolean isArrivalTimeSet();
+  boolean isDepartureTimeSet();
 
-  public int getArrivalTime();
+  int getDepartureTime();
 
-  public void setArrivalTime(int arrivalTime);
+  void setDepartureTime(int departureTime);
 
-  public void clearArrivalTime();
-
-  public boolean isDepartureTimeSet();
-
-  public int getDepartureTime();
-
-  public void setDepartureTime(int departureTime);
-
-  public void clearDepartureTime();
+  void clearDepartureTime();
   
-  public boolean isTimepointSet();
+  boolean isTimepointSet();
   
-  public int getTimepoint();
+  int getTimepoint();
   
-  public void setTimepoint(int timepoint);
+  void setTimepoint(int timepoint);
   
-  public void clearTimepoint();
+  void clearTimepoint();
 
-  public String getStopHeadsign();
+  String getStopHeadsign();
 
-  public void setStopHeadsign(String headSign);
+  void setStopHeadsign(String headSign);
 
-  public String getRouteShortName();
+  String getRouteShortName();
 
-  public void setRouteShortName(String routeShortName);
+  void setRouteShortName(String routeShortName);
 
-  public int getPickupType();
+  int getPickupType();
 
-  public void setPickupType(int pickupType);
+  void setPickupType(int pickupType);
 
-  public int getDropOffType();
+  int getDropOffType();
 
-  public void setDropOffType(int dropOffType);
+  void setDropOffType(int dropOffType);
 
-  public boolean isShapeDistTraveledSet();
+  boolean isShapeDistTraveledSet();
 
-  public double getShapeDistTraveled();
+  double getShapeDistTraveled();
 
-  public void setShapeDistTraveled(double shapeDistTraveled);
+  void setShapeDistTraveled(double shapeDistTraveled);
 
-  public void clearShapeDistTraveled();
+  void clearShapeDistTraveled();
 
-  public BookingRule getPickupBookingRule();
+  BookingRule getPickupBookingRule();
 
-  public void setPickupBookingRule(BookingRule pickupBookingRule);
+  void setPickupBookingRule(BookingRule pickupBookingRule);
 
-  public BookingRule getDropOffBookingRule();
+  BookingRule getDropOffBookingRule();
 
-  public void setDropOffBookingRule(BookingRule dropOffBookingRule);
+  void setDropOffBookingRule(BookingRule dropOffBookingRule);
 
-  public double getMeanDurationFactor();
+  double getMeanDurationFactor();
 	
-  public void setMeanDurationFactor(double meanDurationFactor);	
+  void setMeanDurationFactor(double meanDurationFactor);	
 	
-  public double getMeanDurationOffset();
+  double getMeanDurationOffset();
 	
-  public void setMeanDurationOffset(double meanDurationOffset);
+  void setMeanDurationOffset(double meanDurationOffset);
 	
-  public double getSafeDurationFactor();
+  double getSafeDurationFactor();
 	
-  public void setSafeDurationFactor(double safeDurationFactor);
+  void setSafeDurationFactor(double safeDurationFactor);
 
-  public double getSafeDurationOffset();
+  double getSafeDurationOffset();
 	
-  public void setSafeDurationOffset(double safeDurationOffset);
-
-  public String getFreeRunningFlag();
-
-  public void setFreeRunningFlag(String freeRunningFlag);
+  void setSafeDurationOffset(double safeDurationOffset);
 
 }


### PR DESCRIPTION
Over the years this library has accumulated lots of non-standard fields in stop_times.txt, which have never made it into a standards document and there is very little information about these online.

Sometimes they end up in some feeds and cause problems during parsing.

Nowadays GTFS Flex is standardised so there is no need for these any more, therefore I will remove them.

The fields are:

- `start_service_area_id`
- `end_service_area_id`
- `free_running_flag`
- `departure_buffer`
- `startServiceAreaRadius`
- `endServiceAreaRadius`

Not flex but also non-standard:

- `note`
- `fare_period`
- `track`