### PR TITLE
Parse seconds without regexp

### DIFF
--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/LegacyStopTimeFieldMappingFactory.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/LegacyStopTimeFieldMappingFactory.java
@@ -1,0 +1,27 @@
+package org.onebusaway.jmh.gtfs;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.onebusaway.gtfs.serialization.mappings.InvalidStopTimeException;
+
+public class LegacyStopTimeFieldMappingFactory  {
+
+  private static Pattern _pattern = Pattern.compile("^(-{0,1}\\d+):(\\d{2}):(\\d{2})$");
+
+  public static int getStringAsSeconds(String value) {
+    Matcher m = _pattern.matcher(value);
+    if (!m.matches())
+      throw new InvalidStopTimeException(value);
+    try {
+      int hours = Integer.parseInt(m.group(1));
+      int minutes = Integer.parseInt(m.group(2));
+      int seconds = Integer.parseInt(m.group(3));
+
+      return seconds + 60 * (minutes + 60 * hours);
+    } catch (NumberFormatException ex) {
+      throw new InvalidStopTimeException(value);
+    }
+  }
+
+}

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/ParseBenchmark.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/ParseBenchmark.java
@@ -1,0 +1,80 @@
+package org.onebusaway.jmh.gtfs;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.serialization.GtfsReader;
+import org.onebusaway.gtfs.serialization.mappings.StopTimeFieldMappingFactory;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(time=5, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Measurement(time=5, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Timeout(timeUnit=TimeUnit.SECONDS, time=5)
+public class ParseBenchmark {
+
+  @State(Scope.Thread)
+  public static class ThreadState {
+    List<String> time = new ArrayList<>();
+    public ThreadState() {
+      
+      time.add("00:00:00");
+      time.add("-00:00:00");
+
+      time.add("00:01:00");
+      time.add("-00:01:00");
+
+      time.add("01:01:00");
+      time.add("-01:01:00");
+
+      time.add("10:20:30");
+      time.add("-10:20:30");
+
+      time.add("100:15:13");
+      time.add("-100:15:13");
+    }
+  }
+  
+  @Benchmark
+  public long testStopTimeFieldMappingFactory(ThreadState state) throws Exception {
+    long count = 0;
+    for(String time : state.time) {
+      count += StopTimeFieldMappingFactory.getStringAsSeconds(time); 
+    }
+    return count;
+  }
+  
+  
+  @Benchmark
+  public long testLegacyStopTimeFieldMappingFactory(ThreadState state) throws Exception {
+    long count = 0;
+    for(String time : state.time) {
+      count += LegacyStopTimeFieldMappingFactory.getStringAsSeconds(time); 
+    }
+    return count;
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(ParseBenchmark.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
**Summary:**
Improve costly parse method. 

**Expected behavior:** 
Improved performance.

```
Benchmark                                              Mode  Cnt     Score     Error   Units
ParseBenchmark.testLegacyStopTimeFieldMappingFactory  thrpt    5  1248,575 ±  56,087  ops/ms
ParseBenchmark.testStopTimeFieldMappingFactory        thrpt    5  7665,429 ± 382,586  ops/ms
```
Note: Includes a `LegacyStopTimeFieldMappingFactory` for direct comparison between two methods , this can be deleted as part of QA process.

https://github.com/OneBusAway/onebusaway-gtfs-modules/issues/352

- [x] Linked all relevant issues
