### PR TITLE
Avoid calling HashMap containsKey(..) before get(..)

### DIFF
--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/schema/AbstractFieldMapping.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/schema/AbstractFieldMapping.java
@@ -125,9 +125,12 @@ public abstract class AbstractFieldMapping implements SingleFieldMapping {
     return isMissing(csvValues, _csvFieldName);
   }
 
-  protected static boolean isMissing(Map<String, Object> csvValues,
-      String csvFieldName) {
-    return !(csvValues.containsKey(csvFieldName) && csvValues.get(csvFieldName).toString().length() > 0);
+  protected static boolean isMissing(Map<String, Object> csvValues, String csvFieldName) {
+    Object object = csvValues.get(csvFieldName);
+    if(object == null) {
+      return true;
+    }
+    return object.toString().length() == 0;
   }
 
   protected boolean isMissing(BeanWrapper object) {


### PR DESCRIPTION
**Summary:**
Avoid HashMap containsKey(..) before get(..). Rather get(..) then null check.

**Expected behavior:** 
Actually did not benchmark this as it is a classic performance improvement.

https://github.com/OneBusAway/onebusaway-gtfs-modules/issues/352

- [x] Linked all relevant issues
