### PR TITLE
For disussion: Inflight unzip

### DIFF
--- a/onebusaway-csv-entities/pom.xml
+++ b/onebusaway-csv-entities/pom.xml
@@ -27,6 +27,11 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${commons-compress.version}</version>
+    </dependency>    
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CsvEntityReader.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CsvEntityReader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -129,7 +130,7 @@ public class CsvEntityReader {
         _context, schema, _handler);
     entityLoader.setTrimValues(_trimValues);
 
-    BufferedReader lineReader = new BufferedReader(reader);
+    BufferedReader lineReader = new BufferedReader(reader, 32 * 1024);
 
     /**
      * Skip the initial UTF BOM, if present

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/CommonsZipFileCsvInputSource.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/CommonsZipFileCsvInputSource.java
@@ -26,17 +26,17 @@ import org.onebusaway.csv_entities.CsvInputSource;
 public class CommonsZipFileCsvInputSource implements CsvInputSource {
 
   private ZipFile _zipFile;
-  private UrlByteChannelCache cache;
-  private UrlSeekableByteChannel channel;
-  private int maxBytesPerSecond;
+  private UrlByteChannelCache _cache;
+  private UrlSeekableByteChannel _channel;
+  private int _maxBytesPerSecond;
   
   public CommonsZipFileCsvInputSource(URL url, int chunkLength, int maxBytesPerSecond) throws IOException {
-    this.cache = new UrlByteChannelCache(url, chunkLength);
-    this.maxBytesPerSecond = maxBytesPerSecond;
+    this._cache = new UrlByteChannelCache(url, chunkLength);
+    this._maxBytesPerSecond = maxBytesPerSecond;
     
-    this.channel = new UrlSeekableByteChannel(64 * 1024, cache);
+    this._channel = new UrlSeekableByteChannel(64 * 1024, _cache);
     
-    this._zipFile = ZipFile.builder().setSeekableByteChannel(channel).get();
+    this._zipFile = ZipFile.builder().setSeekableByteChannel(_channel).get();
   }
 
   public boolean hasResource(String name) throws IOException {
@@ -51,7 +51,7 @@ public class CommonsZipFileCsvInputSource implements CsvInputSource {
     long length = entry.getCompressedSize();
     
     try {
-      channel.transfer((int)offset, (int)length, maxBytesPerSecond);
+      _channel.transfer((int)offset, (int)length, _maxBytesPerSecond);
     } catch (InterruptedException e) {
       throw new IOException(e);
     }

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/CommonsZipFileCsvInputSource.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/CommonsZipFileCsvInputSource.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.csv_entities.zip;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.onebusaway.csv_entities.CsvInputSource;
+
+public class CommonsZipFileCsvInputSource implements CsvInputSource {
+
+  private ZipFile _zipFile;
+  private UrlByteChannelCache cache;
+  private UrlSeekableByteChannel channel;
+  private int maxBytesPerSecond;
+  
+  public CommonsZipFileCsvInputSource(URL url, int chunkLength, int maxBytesPerSecond) throws IOException {
+    this.cache = new UrlByteChannelCache(url, chunkLength);
+    this.maxBytesPerSecond = maxBytesPerSecond;
+    
+    this.channel = new UrlSeekableByteChannel(64 * 1024, cache);
+    
+    this._zipFile = ZipFile.builder().setSeekableByteChannel(channel).get();
+  }
+
+  public boolean hasResource(String name) throws IOException {
+    ZipArchiveEntry entry = _zipFile.getEntry(name);
+    return entry != null;
+  }
+
+  public InputStream getResource(String name) throws IOException {
+    ZipArchiveEntry entry = _zipFile.getEntry(name);
+    
+    long offset = entry.getDataOffset();
+    long length = entry.getCompressedSize();
+    
+    try {
+      channel.transfer((int)offset, (int)length, maxBytesPerSecond);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+    
+    return _zipFile.getInputStream(entry);
+  }
+
+  public void close() throws IOException {
+    _zipFile.close();
+  }
+}

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/UrlByteChannelCache.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/UrlByteChannelCache.java
@@ -1,0 +1,212 @@
+package org.onebusaway.csv_entities.zip;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.ByteBuffer;
+
+import org.apache.commons.io.input.ThrottledInputStream;
+import org.apache.commons.io.input.ThrottledInputStream.Builder;
+
+/**
+ * Byte-array cache for remote HTTP content. Sees the remote content as a number of segments which are
+ * locked and downloaded individually. 
+ */
+
+public class UrlByteChannelCache {
+
+  private static class Part {
+    private volatile byte[] content;
+
+    public void downloaded(byte[] content) {
+      this.content = content;
+    }
+
+    public boolean isDownloaded() {
+      return content != null;
+    }
+
+  }
+
+  protected volatile int size = -1;
+  protected URL url;
+  protected int chunkLength;
+  protected Part[] parts;
+
+  public UrlByteChannelCache(URL url, int chunkLength) {
+    this.url = url;
+    this.chunkLength = chunkLength;
+  }
+
+  protected int getSize() throws IOException {
+    URLConnection connection = openConnection();
+    if(connection instanceof HttpURLConnection c) {
+      c.setRequestMethod("HEAD");
+
+      int responseCode = c.getResponseCode();
+      if(responseCode == 200) {
+        return c.getContentLength();
+      } else {
+        throw new IOException("Expected HTTP code 200, got " + responseCode);
+      }
+    }
+    return connection.getContentLength();
+  }
+
+  public void ensureContentBytes(int position, int wanted) throws IOException {
+    int startIndex = position / chunkLength;
+    int endIndex = (position + wanted) / chunkLength;
+
+    ensureContentIndex(startIndex, endIndex);
+  }
+  
+  public boolean hasContentBytes(int position, int wanted) throws IOException {
+    int startIndex = position / chunkLength;
+    int endIndex = (position + wanted) / chunkLength;
+
+    for(int i = startIndex; i <= endIndex; i++) {
+      if(!parts[i].isDownloaded()) {
+        return false;
+      }
+    }
+    
+    return true;
+  }
+
+  public void ensureContentIndex(int startIndex, int endIndex) throws IOException {
+
+    int length = endIndex - startIndex + 1;
+
+    if(length == 1 && parts[startIndex].isDownloaded()) { // optimization for most common cause
+      return;
+    }
+
+    int currentStartIndex = startIndex;
+
+    do {
+      // greedy, request multiple parts per request
+      // find start
+      while(currentStartIndex < startIndex + length && parts[currentStartIndex].isDownloaded()) {
+        currentStartIndex++;
+      }
+
+      if(currentStartIndex == startIndex + length) {
+        break;
+      }
+
+      // find end
+      int currentLength = 1;
+      while(currentStartIndex + currentLength < startIndex + length && !parts[currentStartIndex + currentLength].isDownloaded()) {
+        currentLength++;
+      }
+
+      if(currentLength == 0) {
+        break;
+      }
+
+      InputStream inputStream = openInputStream((currentStartIndex * chunkLength), Math.min(size, (currentStartIndex + currentLength) * chunkLength) - 1);
+
+      // directly create output byte arrays on-the-go
+      byte[] buffer = new byte[16 * 1024];
+
+      for(int i = currentStartIndex; i < currentStartIndex + currentLength; i++) {
+        byte[] partContent = new byte[Math.min(chunkLength, size - currentStartIndex * chunkLength)];
+
+        int index = 0;
+
+        int read;
+        do {
+          read = inputStream.read(buffer, 0, Math.min(partContent.length - index, buffer.length));
+          if(read == -1) {
+            break;
+          }
+
+          System.arraycopy(buffer, 0, partContent, index, read);
+
+          index += read;
+        } while(index < partContent.length);
+
+        parts[i].downloaded(partContent);
+      }
+
+      currentStartIndex = currentStartIndex + currentLength;
+    } while(currentStartIndex < startIndex + length);
+
+  }
+
+  protected URLConnection openConnection() throws IOException {
+    return url.openConnection();
+  }
+
+  protected InputStream openInputStream(int start, int end, int maxBytesPerSecond) throws IOException {
+    InputStream is = openInputStream(start, end);
+    if(maxBytesPerSecond == -1) {
+      return is;
+    }
+    Builder builder = ThrottledInputStream.builder();
+    builder.setInputStream(is);
+    builder.setMaxBytesPerSecond(maxBytesPerSecond);
+    return builder.get();
+  }
+
+  protected InputStream openInputStream(int start, int end) throws IOException {
+    URLConnection connection = url.openConnection();
+    if(connection instanceof HttpURLConnection c) {
+
+      c.setRequestProperty("Range", "bytes=" + start +"-" + end);
+      int responseCode = c.getResponseCode();
+      if(responseCode == 200 || responseCode == 206) {
+        return c.getInputStream();		
+      } else {
+        throw new IOException("Expected HTTP code 200, got " + responseCode);
+      } 
+    }
+    InputStream inputStream = connection.getInputStream();
+    if(inputStream instanceof FileInputStream fin) {
+      fin.getChannel().position(start);
+    } else {
+      inputStream.skip(start);
+    }
+    return inputStream;
+  }
+
+  public int size() throws IOException {
+    if(size == -1) {
+      synchronized(this) {
+        if(size == -1) {
+          size = getSize();
+
+          int parts = size / chunkLength;
+          if(size % chunkLength != 0) {
+            parts++;
+          }
+
+          this.parts = new Part[parts];
+          for(int i = 0; i < parts; i++) {
+            this.parts[i] = new Part();
+          }
+        }
+      }
+    }
+
+    return size;
+  }
+
+  public int put(ByteBuffer buf, int position, int wanted) throws IOException {
+    int startIndex = position / chunkLength;
+    int endIndex = (position + wanted) / chunkLength;
+
+    ensureContentIndex(startIndex, endIndex);
+
+    int offest = position - startIndex * chunkLength;
+    int length = Math.min(wanted, parts[startIndex].content.length - offest);
+
+    buf.put(parts[startIndex].content, offest, length);
+
+    return length;
+  }
+
+}

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/UrlSeekableByteChannel.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/UrlSeekableByteChannel.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SeekableByteChannel;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -31,17 +30,6 @@ public class UrlSeekableByteChannel implements SeekableByteChannel {
   public UrlSeekableByteChannel(int chunkLength, UrlByteChannelCache cache) {
     this.chunkLength = chunkLength;
     this.cache = cache;
-  }
-
-  public final void readFully(InputStream in, byte[] b, int off, int len) throws IOException {
-    Objects.checkFromIndexSize(off, len, b.length);
-    int n = 0;
-    while (n < len) {
-      int count = in.read(b, off + n, len - n);
-      if (count < 0)
-        throw new EOFException();
-      n += count;
-    }
   }
 
   @Override
@@ -171,7 +159,7 @@ public class UrlSeekableByteChannel implements SeekableByteChannel {
         int len = length;
         int off = 0;
         try {
-          System.out.println("Transfer whole file: " + offset + " -> " + length);
+          System.out.println("Transfer full zip file: " + offset + " -> " + length);
           try (InputStream is = cache.openInputStream(offset, offset + length - 1, maxBytesPerSecond)) {
             int n = 0;
             while (n < len) {
@@ -197,7 +185,7 @@ public class UrlSeekableByteChannel implements SeekableByteChannel {
             UrlSeekableByteChannel.this.notify();
           }
 
-          System.out.println("Transferred " + offset + " " + length);
+          System.out.println("Transferred full zip file " + offset + " -> " + length);
         } catch(Exception e) {
           throw new RuntimeException(e);
         }

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/UrlSeekableByteChannel.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/zip/UrlSeekableByteChannel.java
@@ -1,0 +1,208 @@
+package org.onebusaway.csv_entities.zip;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class UrlSeekableByteChannel implements SeekableByteChannel {
+
+  private final AtomicBoolean closed = new AtomicBoolean();
+  private int position;
+
+  private UrlByteChannelCache cache;
+
+  protected int chunkLength;
+
+  protected byte[] zipArchiveEntryBuffer = new byte[] {};
+  protected int zipArchiveEntryPosition = 0;
+  protected AtomicInteger zipArchiveEntryChunks = new AtomicInteger();
+  protected Thread zipArchiveEntryReaderThread;
+
+  public UrlSeekableByteChannel(UrlByteChannelCache cache) {
+    this(1024 * 1024, cache);
+  }
+
+  public UrlSeekableByteChannel(int chunkLength, UrlByteChannelCache cache) {
+    this.chunkLength = chunkLength;
+    this.cache = cache;
+  }
+
+  public final void readFully(InputStream in, byte[] b, int off, int len) throws IOException {
+    Objects.checkFromIndexSize(off, len, b.length);
+    int n = 0;
+    while (n < len) {
+      int count = in.read(b, off + n, len - n);
+      if (count < 0)
+        throw new EOFException();
+      n += count;
+    }
+  }
+
+  @Override
+  public SeekableByteChannel position(long newPosition) throws IOException {
+    ensureOpen();
+    if (newPosition < 0L || newPosition > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Position has to be in range 0.. " + Integer.MAX_VALUE);
+    }
+    position = (int) newPosition;
+    return this;
+  }
+
+  @Override
+  public long position() {
+    return position;
+  }
+
+  @Override
+  public SeekableByteChannel truncate(long newSize) {
+    throw new RuntimeException();
+  }
+
+  @Override
+  public int read(ByteBuffer buf) throws IOException {
+
+    ensureOpen();
+
+    if(zipArchiveEntryPosition <= position && position < zipArchiveEntryPosition + zipArchiveEntryBuffer.length) {
+      // within current buffer
+      int wanted = buf.remaining();
+
+      int possible;
+      synchronized(this) {
+        int limit = zipArchiveEntryPosition + chunkLength * zipArchiveEntryChunks.get();
+
+        possible = limit - position;
+        if(possible <= 0) {
+          try {
+            this.wait();
+          } catch (InterruptedException e) {
+            throw new IOException("Unable to read " + position + " -> " + wanted, e);
+          }
+          limit = zipArchiveEntryPosition + chunkLength * zipArchiveEntryChunks.get();
+
+          possible = limit - position;
+          if(possible <= 0) {
+            throw new IOException("Unable to read " + position + " -> " + wanted);
+          }
+        }
+      }
+
+      int read = Math.min(wanted, possible);
+      buf.put(zipArchiveEntryBuffer, position - zipArchiveEntryPosition, read);
+      
+      position += read;
+      
+      return read;
+
+    } else {
+      // random access from underlying cache
+      // typically for reading headers / manifest
+      
+      int wanted = buf.remaining();
+      int possible = cache.size() - position;
+      if (possible <= 0) {
+        return -1;
+      }
+      if (wanted > possible) {
+        wanted = possible;
+      }
+
+      int read = cache.put(buf, position, wanted);
+
+      position += read;
+      return read;
+    }
+  }
+
+
+  @Override
+  public void close() {
+    closed.set(true);
+  }
+
+  @Override
+  public boolean isOpen() {
+    return !closed.get();
+  }
+
+  @Override
+  public int write(ByteBuffer b) throws IOException {
+    throw new RuntimeException();
+  }
+
+  private void ensureOpen() throws ClosedChannelException {
+    if (!isOpen()) {
+      throw new ClosedChannelException();
+    }
+  }    
+
+  @Override
+  public long size() throws IOException {
+    return cache.getSize();
+  }
+
+  public void transfer(int offset, int length, int maxBytesPerSecond) throws IOException, InterruptedException {
+    if(zipArchiveEntryReaderThread != null) {
+      zipArchiveEntryReaderThread.join();
+    }
+
+    if(cache.hasContentBytes(offset, length)) {
+      System.out.println("Already have " + offset + " " + length);
+      
+      this.zipArchiveEntryBuffer = new byte[] {};
+      return;
+    }
+    
+    this.zipArchiveEntryChunks.set(0);
+    this.zipArchiveEntryPosition = offset;
+    this.zipArchiveEntryBuffer = new byte[length];
+
+    zipArchiveEntryReaderThread = new Thread() {
+      @Override
+      public void run() {
+        int chunks = 0;
+
+        int len = length;
+        int off = 0;
+        try {
+          System.out.println("Transfer whole file: " + offset + " -> " + length);
+          try (InputStream is = cache.openInputStream(offset, offset + length - 1, maxBytesPerSecond)) {
+            int n = 0;
+            while (n < len) {
+              int count = is.read(zipArchiveEntryBuffer, off + n, len - n);
+              if (count < 0) {
+                throw new EOFException();
+              }
+              n += count;
+
+              if(chunks < n / chunkLength) {
+                chunks = n / chunkLength;
+                
+                synchronized (UrlSeekableByteChannel.this) {
+                  zipArchiveEntryChunks.set(chunks);
+                  UrlSeekableByteChannel.this.notify();
+                }
+              }
+            }
+          }
+
+          synchronized (UrlSeekableByteChannel.this) {
+            zipArchiveEntryChunks.set(length / chunkLength + (length % chunkLength == 0 ? 0 : 1) );
+            UrlSeekableByteChannel.this.notify();
+          }
+
+          System.out.println("Transferred " + offset + " " + length);
+        } catch(Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+    zipArchiveEntryReaderThread.start();
+  }
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
@@ -123,6 +123,11 @@ public class GtfsReader extends CsvEntityReader {
 
     addEntityHandler(new EntityHandlerImpl());
   }
+  
+  public void setInputSource(CsvInputSource source) {
+    super.setInputSource(source);
+  }
+
 
   public void setInputLocation(File path) throws IOException {
     super.setInputLocation(path);

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/GtfsTestData.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/GtfsTestData.java
@@ -19,11 +19,13 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.onebusaway.csv_entities.schema.BeanWrapper;
 import org.onebusaway.csv_entities.schema.BeanWrapperFactory;
+import org.onebusaway.csv_entities.zip.CommonsZipFileCsvInputSource;
 import org.onebusaway.gtfs.serialization.GtfsReader;
 import org.onebusaway.gtfs.services.GenericMutableDao;
 
@@ -54,6 +56,8 @@ public class GtfsTestData {
   public static final String LOCATIONS_GEOJSON = gtfsPath("locations.geojson");
 
   public static final String TEST_AGENCY_VEHICLES_EXT_GTFS = gtfsPath("testagency-vehicles-ext");
+
+  public static final String ENTUR_GTFS = gtfsPath("rb_norway-aggregated-gtfs-basic.zip");
 
   public static File getCaltrainGtfs() {
     return getResourceAsTemporaryFile(CALTRAIN_GTFS);
@@ -99,6 +103,10 @@ public class GtfsTestData {
   public static File getTestAgencyVehiclesExt(){
     return new File("src/test/resources", TEST_AGENCY_VEHICLES_EXT_GTFS);
   }
+  
+  public static File getEnturGtfs(){
+    return new File("src/test/resources", ENTUR_GTFS);
+  }
 
   public static <T extends GenericMutableDao> void readGtfs(T entityStore,
       File resourcePath, String defaultAgencyId) throws IOException {
@@ -112,6 +120,20 @@ public class GtfsTestData {
 
     reader.run();
   }
+  
+  public static <T extends GenericMutableDao> void readGtfs(T entityStore,
+      URL resourceUrl, String defaultAgencyId, int maxBytesPerSecond) throws IOException {
+
+    GtfsReader reader = new GtfsReader();
+    reader.setDefaultAgencyId(defaultAgencyId);
+    
+    reader.setInputSource(new CommonsZipFileCsvInputSource(resourceUrl, 1024 * 1024, maxBytesPerSecond));
+
+    reader.setEntityStore(entityStore);
+
+    reader.run();
+  }
+
 
   private static File getResourceAsTemporaryFile(String path) {
     try {

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/impl/GtfsRelationalDaoImplTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/impl/GtfsRelationalDaoImplTest.java
@@ -16,12 +16,28 @@
  */
 package org.onebusaway.gtfs.impl;
 
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+
 import static  org.junit.jupiter.api.Assertions.assertEquals;
 import static  org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.ThrottledInputStream;
+import org.apache.commons.io.input.ThrottledInputStream.Builder;
 import org.junit.jupiter.api.Test;
 import org.onebusaway.gtfs.GtfsTestData;
 import org.onebusaway.gtfs.model.Agency;
@@ -121,39 +137,39 @@ public class GtfsRelationalDaoImplTest {
     assertTrue(agencyIds.contains("A"));
     assertTrue(agencyIds.contains("B"));
   }
-  
+
   @Test
   public void testStationSubStops() {
-	  
-	  GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
-	  
-	  Stop st = new Stop();
-	  st.setLocationType(1);
-	  st.setId(new AgencyAndId("X", "ST"));
-	  dao.saveEntity(st);
-	  
-	  Stop st1 = new Stop();
-	  st1.setLocationType(0);
-	  st1.setId(new AgencyAndId("X", "ST1"));
-	  st1.setParentStation("ST");
-	  dao.saveEntity(st1);
-	  
-	  Stop st2 = new Stop();
-	  st2.setLocationType(0);
-	  st2.setId(new AgencyAndId("X", "ST2"));
-	  st2.setParentStation("ST");
-	  dao.saveEntity(st2);
 
-	  Stop st3 = new Stop();
-	  st3.setLocationType(0);
-	  st3.setId(new AgencyAndId("X", "ST3"));
-	  dao.saveEntity(st3);
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
 
-	  List<Stop> sts = dao.getStopsForStation(st);
-	  assertTrue(sts.contains(st1));
-	  assertTrue(sts.contains(st2));
-	  assertTrue(!sts.contains(st3));
-	  assertEquals(sts.size(), 2);
+    Stop st = new Stop();
+    st.setLocationType(1);
+    st.setId(new AgencyAndId("X", "ST"));
+    dao.saveEntity(st);
+
+    Stop st1 = new Stop();
+    st1.setLocationType(0);
+    st1.setId(new AgencyAndId("X", "ST1"));
+    st1.setParentStation("ST");
+    dao.saveEntity(st1);
+
+    Stop st2 = new Stop();
+    st2.setLocationType(0);
+    st2.setId(new AgencyAndId("X", "ST2"));
+    st2.setParentStation("ST");
+    dao.saveEntity(st2);
+
+    Stop st3 = new Stop();
+    st3.setLocationType(0);
+    st3.setId(new AgencyAndId("X", "ST3"));
+    dao.saveEntity(st3);
+
+    List<Stop> sts = dao.getStopsForStation(st);
+    assertTrue(sts.contains(st1));
+    assertTrue(sts.contains(st2));
+    assertTrue(!sts.contains(st3));
+    assertEquals(sts.size(), 2);
   }
 
   @Test
@@ -164,4 +180,181 @@ public class GtfsRelationalDaoImplTest {
     List<Trip> trips = dao.getTripsForBlockId(new AgencyAndId(agencyId, "block.1"));
     assertEquals(2, trips.size());
   }
+
+  @Test
+  public void testEnturFile() throws IOException {
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+    GtfsTestData.readGtfs(dao, GtfsTestData.getEnturGtfs(), "ENTUR");
+  }
+
+  @Test
+  public void testEnturFileURL() throws IOException {
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+    GtfsTestData.readGtfs(dao, GtfsTestData.getEnturGtfs().toURL(), "ENTUR", -1);
+  }
+
+  @Test
+  public void testEnturParseInflightURL() throws Exception {
+
+    int bandwithInMegaBytesPerSecond = 5;
+
+    File enturGtfs = GtfsTestData.getEnturGtfs();
+
+    HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
+    server.createContext("/gtfs.zip", new GtfsServerHandler(enturGtfs, bandwithInMegaBytesPerSecond));
+    server.setExecutor(null); // creates a default executor
+    server.start();
+
+    try {
+      URL url = new URL("http://127.0.0.1:8000/gtfs.zip");
+      //URL url = new URL("https://storage.googleapis.com/marduk-production/outbound/gtfs/rb_norway-aggregated-gtfs.zip");
+
+      GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+      GtfsTestData.readGtfs(dao, url, "ENTUR", -1);
+
+    } finally {
+      server.stop(1);
+    }
+  }
+
+  @Test
+  public void testEnturSaveURLToFileAndParse() throws Exception {
+
+    int bandwithInMegaBytesPerSecond = 5;
+    
+    File enturGtfs = GtfsTestData.getEnturGtfs();
+
+    HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
+    server.createContext("/gtfs.zip", new GtfsServerHandler(enturGtfs, bandwithInMegaBytesPerSecond));
+    server.setExecutor(null); // creates a default executor
+    server.start();
+
+    try {
+      URL url = new URL("http://127.0.0.1:8000/gtfs.zip");
+      //URL url = new URL("https://storage.googleapis.com/marduk-production/outbound/gtfs/rb_norway-aggregated-gtfs.zip");
+
+      long timestamp = System.currentTimeMillis();
+      File file = File.createTempFile("gtfs-", ".zip");
+      file.deleteOnExit();
+      
+      try (InputStream in = url.openStream();
+          FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+        byte dataBuffer[] = new byte[16 * 1024];
+        int bytesRead;
+        while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
+          fileOutputStream.write(dataBuffer, 0, bytesRead);
+        }
+      }
+      long duration = System.currentTimeMillis() - timestamp;
+      
+      System.out.println("Transferred file size " + (file.length() / 1000_000) + "MB in " + duration + "ms (" + (file.length() / (duration * 1000) + "MB/s)") );
+
+      GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+      GtfsTestData.readGtfs(dao, file, "ENTUR");
+
+    } finally {
+      server.stop(1);
+    }
+  }
+
+  static class GtfsServerHandler implements HttpHandler {
+
+    private final File file;
+    private final int bandwithInMegaBytesPerSecond;
+
+    public GtfsServerHandler(File file, int bandwithInMegaBytesPerSecond) {
+      this.file = file;
+      this.bandwithInMegaBytesPerSecond = bandwithInMegaBytesPerSecond;
+    }
+
+    @Override
+    public void handle(HttpExchange t) throws IOException {
+      String requestMethod = t.getRequestMethod();
+      boolean skipBody = requestMethod.equals("HEAD");
+
+      Headers requestHeaders = t.getRequestHeaders();
+      String range = requestHeaders.getFirst("Range");
+      if(range == null) {
+        Headers responseHeaders = t.getResponseHeaders();
+        responseHeaders.set("Content-Length", Long.toString(file.length()));
+        if(skipBody) {
+          t.sendResponseHeaders(200, -1);
+          t.close();
+          return;
+        }
+        t.sendResponseHeaders(200, file.length());
+
+        OutputStream os = t.getResponseBody();
+        InputStream in = new FileInputStream(file);
+        try {
+          if(bandwithInMegaBytesPerSecond != -1) {
+            Builder builder = ThrottledInputStream.builder();
+            builder.setInputStream(in);
+            builder.setMaxBytesPerSecond(bandwithInMegaBytesPerSecond * 1000_000);
+            in = builder.get();
+          }
+          
+          byte[] buffer = new byte[16 * 1024];
+
+          while(true) {
+            int count = in.read(buffer);
+            if(count <= 0) {
+              break;
+            }
+            os.write(buffer, 0, count);
+          }
+        } finally {
+          os.close();
+          in.close();
+        }
+      } else {
+
+        int equals = range.indexOf('=');
+        int dash = range.indexOf('-');
+
+        int start = Integer.parseInt(range.substring(equals + 1, dash)); // inclusive
+        int end = Integer.parseInt(range.substring(dash + 1)) + 1; // exclusive
+
+        int length = end - start;
+        System.out.println(requestMethod + " " + start + "-" + (end -1));
+        Headers responseHeaders = t.getResponseHeaders();
+        responseHeaders.set("Content-Length", Long.toString(file.length()));
+        if(skipBody) {
+          t.sendResponseHeaders(200, -1);
+          t.close();
+          return;
+        }
+        t.sendResponseHeaders(200, length);
+
+        OutputStream os = t.getResponseBody();
+        try { 
+          FileInputStream fin = new FileInputStream(file);
+          fin.getChannel().position(start);
+
+          InputStream in = fin;
+          if(bandwithInMegaBytesPerSecond != -1) {
+            Builder builder = ThrottledInputStream.builder();
+            builder.setInputStream(fin);
+            builder.setMaxBytesPerSecond(bandwithInMegaBytesPerSecond * 1000_000);
+            in = builder.get();
+          }          
+          
+          byte[] buffer = new byte[16 * 1024];
+
+          while(length > 0) {
+            int count = in.read(buffer, 0, Math.min(buffer.length, length));
+            if(count <= 0) {
+              break;
+            }
+            os.write(buffer, 0, count);
+
+            length -= count;
+          }
+        } finally {
+          os.close();
+        }
+      }
+    }
+  }
+
 }

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/impl/GtfsRelationalDaoImplTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/impl/GtfsRelationalDaoImplTest.java
@@ -196,7 +196,7 @@ public class GtfsRelationalDaoImplTest {
   @Test
   public void testEnturParseInflightURL() throws Exception {
 
-    int bandwithInMegaBytesPerSecond = 5;
+    int bandwithInMegaBytesPerSecond = 30;
 
     File enturGtfs = GtfsTestData.getEnturGtfs();
 
@@ -220,7 +220,7 @@ public class GtfsRelationalDaoImplTest {
   @Test
   public void testEnturSaveURLToFileAndParse() throws Exception {
 
-    int bandwithInMegaBytesPerSecond = 5;
+    int bandwithInMegaBytesPerSecond = 30;
     
     File enturGtfs = GtfsTestData.getEnturGtfs();
 
@@ -241,7 +241,7 @@ public class GtfsRelationalDaoImplTest {
           FileOutputStream fileOutputStream = new FileOutputStream(file)) {
         byte dataBuffer[] = new byte[16 * 1024];
         int bytesRead;
-        while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
+        while ((bytesRead = in.read(dataBuffer, 0, dataBuffer.length)) != -1) {
           fileOutputStream.write(dataBuffer, 0, bytesRead);
         }
       }

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsBenchmark.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsBenchmark.java
@@ -26,7 +26,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @BenchmarkMode(Mode.Throughput)
-@Warmup(time=10, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Warmup(time=10, timeUnit=TimeUnit.SECONDS, iterations=0)
 @Measurement(time=10, timeUnit=TimeUnit.SECONDS, iterations=1)
 @Timeout(timeUnit=TimeUnit.SECONDS, time=10)
 public class GtfsBenchmark {

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsDownloadParseBenchmark.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsDownloadParseBenchmark.java
@@ -1,0 +1,157 @@
+package org.onebusaway.jmh.gtfs;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.input.ThrottledInputStream;
+import org.onebusaway.csv_entities.zip.CommonsZipFileCsvInputSource;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.serialization.GtfsReader;
+import org.onebusaway.gtfs.services.GenericMutableDao;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import com.sun.net.httpserver.HttpServer;
+
+@Fork(1)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Mode.SingleShotTime)
+@Warmup(time=10, timeUnit=TimeUnit.SECONDS, iterations=0)
+@Measurement(time=200, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Timeout(timeUnit=TimeUnit.SECONDS, time=300)
+public class GtfsDownloadParseBenchmark {
+
+  @Param({"5", "10", "15", "20", "25", "30", "40", "50", "60", "80", "100", "125", "150", "200", "500"})
+  public int megabytesPerSecond;
+
+  @State(Scope.Benchmark)
+  public static class ThreadState {
+
+    private URL url;
+    private GtfsServerHandler handler;
+    private HttpServer server;
+
+    public ThreadState()  {
+      handler = new GtfsServerHandler(new File("./src/test/resources/rb_norway-aggregated-gtfs.zip"), -1);
+    }
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+      url = new URL("http://127.0.0.1:8000/gtfs.zip");
+      
+      server = HttpServer.create(new InetSocketAddress(8000), 0);
+      server.createContext("/gtfs.zip", handler);
+      server.setExecutor(null); // creates a default executor
+
+      server.start();
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown(){
+      server.stop(1);
+    }
+    
+    public void setBandwithInMegaBytesPerSecond(int bandwithInMegaBytesPerSecond) {
+      handler.setBandwithInMegaBytesPerSecond(bandwithInMegaBytesPerSecond);;
+    }
+  }
+
+
+  @Benchmark
+  public GtfsRelationalDao testTransferThenParse(ThreadState state) throws Exception {
+    state.setBandwithInMegaBytesPerSecond(megabytesPerSecond);
+    
+    File file = File.createTempFile("gtfs-", ".zip");
+    file.deleteOnExit();
+
+    InputStream in = state.url.openStream();
+    FileOutputStream fileOutputStream = new FileOutputStream(file);
+    try {
+      byte dataBuffer[] = new byte[16 * 1024];
+      int bytesRead;
+      while ((bytesRead = in.read(dataBuffer, 0, dataBuffer.length)) != -1) {
+        fileOutputStream.write(dataBuffer, 0, bytesRead);
+      }
+      fileOutputStream.close();
+      
+      GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+      readGtfs(dao, file, "ENTUR");
+      return dao;
+    } finally {
+      in.close();
+      
+      file.delete();
+    }
+
+  }
+
+  @Benchmark
+  public GtfsRelationalDao testParseDirectlyFromURL(ThreadState state) throws Exception {
+    state.setBandwithInMegaBytesPerSecond(megabytesPerSecond);
+    
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+    readGtfs(dao, state.url, "ENTUR", -1);
+    return dao;
+  }
+
+  public static <T extends GenericMutableDao> void readGtfs(T entityStore,
+      File resourcePath, String defaultAgencyId) throws IOException {
+
+    GtfsReader reader = new GtfsReader();
+    reader.setDefaultAgencyId(defaultAgencyId);
+
+    reader.setInputLocation(resourcePath);
+
+    reader.setEntityStore(entityStore);
+
+    reader.run();
+  }
+
+  public static <T extends GenericMutableDao> void readGtfs(T entityStore,
+      URL resourceUrl, String defaultAgencyId, int maxBytesPerSecond) throws IOException {
+
+    GtfsReader reader = new GtfsReader();
+    reader.setDefaultAgencyId(defaultAgencyId);
+
+    reader.setInputSource(new CommonsZipFileCsvInputSource(resourceUrl, 1024 * 1024, maxBytesPerSecond));
+
+    reader.setEntityStore(entityStore);
+
+    reader.run();
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(GtfsDownloadParseBenchmark.class.getSimpleName())
+        .result("jmh-result-" + Instant.now().toString() + ".json")
+        .resultFormat(ResultFormatType.JSON)
+        .build();
+    new Runner(opt).run();
+  }
+}

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsServerHandler.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsServerHandler.java
@@ -1,0 +1,119 @@
+package org.onebusaway.jmh.gtfs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.commons.io.input.ThrottledInputStream;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+public class GtfsServerHandler implements HttpHandler {
+
+  private final File file;
+  private int bandwithInMegaBytesPerSecond;
+
+  public GtfsServerHandler(File file, int bandwithInMegaBytesPerSecond) {
+    this.file = file;
+    this.bandwithInMegaBytesPerSecond = bandwithInMegaBytesPerSecond;
+  }
+  
+  public void setBandwithInMegaBytesPerSecond(int bandwithInMegaBytesPerSecond) {
+    this.bandwithInMegaBytesPerSecond = bandwithInMegaBytesPerSecond;
+  }
+
+  @Override
+  public void handle(HttpExchange t) throws IOException {
+    String requestMethod = t.getRequestMethod();
+    boolean skipBody = requestMethod.equals("HEAD");
+
+    Headers requestHeaders = t.getRequestHeaders();
+    String range = requestHeaders.getFirst("Range");
+    if(range == null) {
+      Headers responseHeaders = t.getResponseHeaders();
+      responseHeaders.set("Content-Length", Long.toString(file.length()));
+      if(skipBody) {
+        t.sendResponseHeaders(200, -1);
+        t.close();
+        return;
+      }
+      t.sendResponseHeaders(200, file.length());
+
+      System.out.println("HTTP " + requestMethod + " whole file");
+      
+      OutputStream os = t.getResponseBody();
+      InputStream in = new FileInputStream(file);
+      try {
+        if(bandwithInMegaBytesPerSecond != -1) {
+          ThrottledInputStream.Builder builder = ThrottledInputStream.builder();
+          builder.setInputStream(in);
+          builder.setMaxBytesPerSecond(bandwithInMegaBytesPerSecond * 1000_000);
+          in = builder.get();
+        }
+        
+        byte[] buffer = new byte[16 * 1024];
+
+        while(true) {
+          int count = in.read(buffer);
+          if(count <= 0) {
+            break;
+          }
+          os.write(buffer, 0, count);
+        }
+      } finally {
+        os.close();
+        in.close();
+      }
+    } else {
+
+      int equals = range.indexOf('=');
+      int dash = range.indexOf('-');
+
+      int start = Integer.parseInt(range.substring(equals + 1, dash)); // inclusive
+      int end = Integer.parseInt(range.substring(dash + 1)) + 1; // exclusive
+
+      int length = end - start;
+      System.out.println("HTTP " + requestMethod + " " + start + "-" + (end -1));
+      Headers responseHeaders = t.getResponseHeaders();
+      responseHeaders.set("Content-Length", Long.toString(file.length()));
+      if(skipBody) {
+        t.sendResponseHeaders(200, -1);
+        t.close();
+        return;
+      }
+      t.sendResponseHeaders(200, length);
+
+      OutputStream os = t.getResponseBody();
+      try { 
+        FileInputStream fin = new FileInputStream(file);
+        fin.getChannel().position(start);
+
+        InputStream in = fin;
+        if(bandwithInMegaBytesPerSecond != -1) {
+          ThrottledInputStream.Builder builder = ThrottledInputStream.builder();
+          builder.setInputStream(fin);
+          builder.setMaxBytesPerSecond(bandwithInMegaBytesPerSecond * 1000_000);
+          in = builder.get();
+        }          
+        
+        byte[] buffer = new byte[16 * 1024];
+
+        while(length > 0) {
+          int count = in.read(buffer, 0, Math.min(buffer.length, length));
+          if(count <= 0) {
+            break;
+          }
+          os.write(buffer, 0, count);
+
+          length -= count;
+        }
+      } finally {
+        os.close();
+      }
+    }
+  }
+}

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/ParseBenchmark.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/ParseBenchmark.java
@@ -1,15 +1,10 @@
 package org.onebusaway.jmh.gtfs;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
-import org.onebusaway.gtfs.serialization.GtfsReader;
 import org.onebusaway.gtfs.serialization.mappings.StopTimeFieldMappingFactory;
-import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
     <junit.version>5.12.2</junit.version>
     <jmh.version>1.37</jmh.version>
     <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
+    <commons-compress.version>1.27.1</commons-compress.version>
+
   </properties>
 
   <scm>


### PR DESCRIPTION
**Summary:**
Create a `CSVInputSource` which pulls data from an URL to download and parse at the same time.

 * Adds commons-compress dependency for low-level ZIP access.
 * HTTP cache approach with Ranges:
   * Segments for random access (i.e. read various headers / indexes)
     * Transferred on demand
   * ZIP Entry cache (compressed data)
     * Transferred in background thread

**Expected behavior:** 
Improve overall time for download + parse.

For Entur's aggregated GTFS zip file (500+ MB):

```
Benchmark                                            (megabytesPerSecond)  Mode  Cnt    Score   Error  Units
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                     5    ss       118,078           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    10    ss        61,820           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    15    ss        47,379           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    20    ss        48,587           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    25    ss        47,878           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    30    ss        47,813           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    40    ss        47,516           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    50    ss        47,388           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    60    ss        47,911           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                    80    ss        48,128           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                   100    ss        47,811           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                   125    ss        49,662           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                   150    ss        47,737           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                   200    ss        48,675           s/op
GtfsDownloadParseBenchmark.testParseDirectlyFromURL                   500    ss        47,992           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                        5    ss       164,664           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       10    ss       104,925           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       15    ss        85,917           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       20    ss        75,728           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       25    ss        71,392           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       30    ss        66,986           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       40    ss        61,982           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       50    ss        58,279           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       60    ss        56,672           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                       80    ss        53,689           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                      100    ss        54,637           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                      125    ss        52,002           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                      150    ss        50,476           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                      200    ss        49,912           s/op
GtfsDownloadParseBenchmark.testTransferThenParse                      500    ss        47,637           s/op
```
So numbers seem to indicate that the performance is better for low to medium bandwidth, the two approaches converges (as expected) on very high bandwidth (> gigabit) connections.

The big question is how users actually get hold of their GTFS feeds (mounted via filesystem or URL), and if via URL, the  actual bandwidth.

- [ ] Linked all relevant issues
