### PR TITLE
Improve delimited text parser (CSV parsing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pom.xml.releaseBackup
 *.zip
 *.jar
 jmh-result-*.json
+*.log
+

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CSVLibrary.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CSVLibrary.java
@@ -21,6 +21,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -33,8 +34,6 @@ import java.util.List;
  * 
  */
 public class CSVLibrary {
-
-  private final DelimitedTextParser _parser = new DelimitedTextParser(',');
 
   public static String escapeValue(String value) {
     if (value.indexOf(',') != -1 || value.indexOf('"') != -1)
@@ -94,10 +93,6 @@ public class CSVLibrary {
     return csv.toString();
   }
 
-  public void setTrimInitialWhitespace(boolean trimInitialWhitespace) {
-    _parser.setTrimInitialWhitespace(trimInitialWhitespace);
-  }
-
   public final void parse(InputStream is, CSVListener handler) throws Exception {
     BufferedReader reader = new BufferedReader(new InputStreamReader(is));
     parse(reader, handler);
@@ -113,14 +108,16 @@ public class CSVLibrary {
     String line = null;
     int lineNumber = 1;
 
+    List<String> values = new ArrayList<>();
     while ((line = r.readLine()) != null) {
-      List<String> values = parse(line);
+      DelimitedTextParser.parse(line, values);
       try {
         handler.handleLine(values);
       } catch (Exception ex) {
         throw new Exception("error handling csv record for lineNumber="
             + lineNumber, ex);
       }
+      values.clear();
       lineNumber++;
     }
 
@@ -128,6 +125,6 @@ public class CSVLibrary {
   }
 
   public final List<String> parse(String line) {
-    return _parser.parse(line);
+    return DelimitedTextParser.parse(line);
   }
 }

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CSVListener.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CSVListener.java
@@ -18,5 +18,13 @@ package org.onebusaway.csv_entities;
 import java.util.List;
 
 public interface CSVListener {
+
+  /**
+   * Handle CSV line.
+   * 
+   * @param line line parsed to columns. The same {@linkplain List} instance might be (re)used to pass multiple lines.
+   * @throws Exception
+   */
+
   public void handleLine(List<String> line) throws Exception;
 }

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/DelimitedTextParser.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/DelimitedTextParser.java
@@ -42,7 +42,6 @@ public class DelimitedTextParser {
   }
   
   public static List<String> parse(String line) {
-    // set the initial capacity to the same as the previous line
     List<String> tokens = new ArrayList<>();
 
     parse(line, tokens);

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/DelimitedTextParser.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/DelimitedTextParser.java
@@ -25,115 +25,192 @@ import java.util.List;
  * malformed CSV that most parsers would choke on but that agencies produce and
  * google seems to validate as well.
  * 
- * @author bdferris
- * 
  */
 public class DelimitedTextParser {
 
-  private enum EParseState {
-    TRIM_INIT_WHITESPACE, DATA, DATA_IN_QUOTES, END_QUOTE
-  }
-
-  private final char _delimiter;
-
-  private boolean _trimInitialWhitespace = false;
-
-  public DelimitedTextParser(char delimiter) {
-    _delimiter = delimiter;
-  }
-
-  public void setTrimInitialWhitespace(boolean trimInitialWhitespace) {
-    _trimInitialWhitespace = trimInitialWhitespace;
-  }
-
-  public final List<String> parse(String line) {
-
-    StringBuilder token = new StringBuilder();
-    List<StringBuilder> tokens = new ArrayList<StringBuilder>();
-    if (line.length() > 0)
-      tokens.add(token);
-
-    EParseState resetState = _trimInitialWhitespace
-        ? EParseState.TRIM_INIT_WHITESPACE : EParseState.DATA;
-    EParseState state = resetState;
-
-    for (int i = 0; i < line.length(); i++) {
-      char c = line.charAt(i);
-      switch (state) {
-        case TRIM_INIT_WHITESPACE:
-          if (c == _delimiter) {
-            token = new StringBuilder();
-            tokens.add(token);
-          } else {
-            switch (c) {
-              case ' ':
-                break;
-              case '"':
-                if (token.length() == 0)
-                  state = EParseState.DATA_IN_QUOTES;
-                else
-                  token.append(c);
-                break;
-              default:
-                state = EParseState.DATA;
-                token.append(c);
-                break;
-            }
-          }
-          break;
-        case DATA:
-          if (c == _delimiter) {
-            token = new StringBuilder();
-            tokens.add(token);
-            state = resetState;
-          } else {
-            switch (c) {
-              case '"':
-                if (token.length() == 0)
-                  state = EParseState.DATA_IN_QUOTES;
-                else
-                  token.append(c);
-                break;
-              default:
-                token.append(c);
-                break;
-            }
-          }
-          break;
-        case DATA_IN_QUOTES:
-          switch (c) {
-            case '"':
-              state = EParseState.END_QUOTE;
-              break;
-            default:
-              token.append(c);
-              break;
-          }
-          break;
-        case END_QUOTE:
-          if (c == _delimiter) {
-            token = new StringBuilder();
-            tokens.add(token);
-            state = resetState;
-            break;
-          } else {
-            switch (c) {
-              case '"':
-                token.append('"');
-                state = EParseState.DATA_IN_QUOTES;
-                break;
-              default:
-                token.append(c);
-                state = EParseState.DATA;
-                break;
-            }
-          }
-          break;
-      }
+  public static void parse(String line, List<String> tokens) {
+    if (line.length() == 0) {
+      tokens.add("");
+      return;
     }
-    List<String> retro = new ArrayList<String>(tokens.size());
-    for (StringBuilder b : tokens)
-      retro.add(b.toString());
-    return retro;
+    parseImpl(line, tokens);
+    
+    if (line.charAt(line.length() - 1) == ',') {
+      // delimiter followed by end of line
+      tokens.add("");
+    }
   }
+  
+  public static List<String> parse(String line) {
+    // set the initial capacity to the same as the previous line
+    List<String> tokens = new ArrayList<>();
+
+    parse(line, tokens);
+    
+    return tokens;
+  }
+
+  private static void parseImpl(String line, List<String> tokens) {
+    // Definitions:
+    // Divider: the comma character
+    // Column: characters between dividers, after the last divider of the line or before the first divider of the line.
+    // Quoted: characters between two double quotes
+    //
+    // Rules:
+    // * to be a Quoted Column, the first and last Column char must be a double quote character.
+    // * within a Quoted Column:
+    // ** two double quote characters after one another is considered an escaped double quote
+    // ** the divider counts as a regular character
+    // * after the end quote, the only legal character is the divider (if not end-of-line)
+    //
+    // Performance considerations:
+    //
+    // Assume most frequent input data:
+    // 1.unquoted value
+    // 2.empty value
+    // 3.quoted value without escaped content
+    // 4.quoted value with escaped content
+    //
+    // Try to avoid using a StringBuilder, rather substring the String directly
+    // whenever possible.
+    
+    int lineLength = line.length();
+    int i = 0;
+
+    // Example line content:
+    // |----------------------------------------- 
+    // | abcd,1234,,"xyz","text with "" escape",
+    // |----------------------------------------- 
+    //
+    // consisting of the following columns:
+    // 0: text column: abcd
+    // 1: text column: 1234
+    // 2: empty column
+    // 3: quoted column: xyz
+    // 4: quoted column (with escaped value): text with " escape
+    // 5: empty column
+    //
+    // Possible values of index i at the top of main loop below.
+    //
+    // |-------------------------------------------
+    // | abcd,1234,,"xyz","text with "" escape",
+    // | ^    ^    ^^     ^                     ^
+    // |-------------------------------------------
+    //
+    // each main loop iteration reads one column. 
+    //
+    // Note: This approach does not handle an empty last column, this is left
+    // up to the calling method.
+    
+    main: while (i < lineLength) {
+      char c = line.charAt(i);
+
+      if (c == ',') {
+        // empty column
+        tokens.add("");
+
+        i++;
+        continue;
+      }
+
+      if (c == '"') {
+        // quoted column
+        int startIndex = i + 1;
+
+        do {
+          i++;
+          if (i >= lineLength) {
+            // last column
+            // open-ended quoted value
+            throw new IllegalStateException("Expected double quoted followed by delimiter or another double quote");
+          }
+        } while (line.charAt(i) != '"');
+
+        int endIndex = i;
+        i++;
+        if (i >= lineLength) {
+          // last column
+          // quoted column but no escaped values within
+          tokens.add(line.substring(startIndex, endIndex));
+
+          break main;
+        }
+
+        if (line.charAt(i) == ',') {
+          // quoted column but no escaped values within
+          tokens.add(line.substring(startIndex, endIndex));
+
+          i++;
+          continue main;
+        }
+        
+        if (line.charAt(i) != '"') {
+          // unexpected non-quoted chars
+          throw new IllegalStateException("Expected double quote followed by delimiter or another double quote");
+        }
+
+        // quoted column with escaped value within
+        i = handleQuotedColumnWithEscape(line, tokens, startIndex, endIndex, i, lineLength);
+        continue main;
+      } 
+
+      // text column
+      // find delimiter
+      int startIndex = i;
+      do {
+        i++;
+      } while (i < lineLength && line.charAt(i) != ',');
+
+      tokens.add(line.substring(startIndex, i));
+
+      i++;
+    }
+  }
+
+  private static int handleQuotedColumnWithEscape(String line, List<String> tokens, int startIndex, int endIndex, int i,
+      int lineLength) {
+    // escaped value not yet at delimiter
+    StringBuilder builder = new StringBuilder(Math.min(line.length() - startIndex, (endIndex - startIndex) * 2)); // rough estimate
+    builder.append(line, startIndex, endIndex);
+
+    // found double quotes
+    do {
+      // append double quotes as single quote
+      builder.append('"');
+
+      startIndex = i + 1;
+
+      do {
+        i++;
+        if (i >= lineLength) {
+          // last column
+          // open-ended quoted value
+          throw new IllegalStateException("Expected end-quote");
+        }
+      } while (line.charAt(i) != '"');
+
+      builder.append(line, startIndex, i);
+
+      i++; // skip over first double quote
+      if (i >= lineLength) {
+        // last column
+        tokens.add(builder.toString());
+
+        return i;
+      }
+      
+      // only acceptable chars: divider and double quote
+      if (line.charAt(i) == ',') {
+        tokens.add(builder.toString());
+        
+        i++;
+        return i;
+      } else if (line.charAt(i) != '"') {
+        throw new IllegalStateException("Expected end of line or divider after double quote");
+      }
+
+    } while (true);
+
+  }
+
 }

--- a/onebusaway-csv-entities/src/test/java/org/onebusaway/csv_entities/CSVLibraryTest.java
+++ b/onebusaway-csv-entities/src/test/java/org/onebusaway/csv_entities/CSVLibraryTest.java
@@ -17,7 +17,7 @@
 package org.onebusaway.csv_entities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,22 +59,18 @@ class CSVLibraryTest {
 
   @Test
   void testParseQuotesWithEscapedDoubleQuoteAndUnexpectedTrailingChars() {
-    try {
-      _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck\" is expensive");
-      fail();
-    } catch(Exception e) {
-
-    }
+    assertThrows(Exception.class,
+        () -> _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck\" is expensive"),
+        "Expected exception"
+        );
   }
 
   @Test
   void testParseQuotesWithUnexpectedTrailingChars() {
-    try {
-      _csv.parse("1997,Ford,E350,\"Super truck\" is expensive");
-      fail();
-    } catch(Exception e) {
-
-    }
+    assertThrows(Exception.class,
+        () -> _csv.parse("1997,Ford,E350,\"Super truck\" is expensive"),
+        "Expected exception"
+        );
   }
 
   @Test
@@ -172,12 +168,10 @@ class CSVLibraryTest {
 
   @Test
   void testParseOpenQuotedLastColumnFails() {
-    try {
-      _csv.parse("\"open");
-      fail();
-    } catch(Exception e) {
-
-    }
+    assertThrows(Exception.class,
+        () -> _csv.parse("\"open"),
+        "Expected exception"
+        );
   }
 
   @Test
@@ -241,12 +235,10 @@ class CSVLibraryTest {
 
   @Test
   void testParseOpenQuoteWithEscapes() {
-    try {
-      _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck");
-      fail();
-    } catch(Exception e) {
-
-    }
+    assertThrows(Exception.class,
+        () -> _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck"),
+        "Expected exception"
+        );
   }
 
 }

--- a/onebusaway-csv-entities/src/test/java/org/onebusaway/csv_entities/CSVLibraryTest.java
+++ b/onebusaway-csv-entities/src/test/java/org/onebusaway/csv_entities/CSVLibraryTest.java
@@ -17,6 +17,7 @@
 package org.onebusaway.csv_entities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,23 +33,48 @@ class CSVLibraryTest {
   }
 
   @Test
-  void testParse() {
-
+  void testParseLetters() {
     List<String> tokens = _csv.parse("a,b,c");
     assertEquals(3, tokens.size());
     assertEquals("a", tokens.get(0));
     assertEquals("b", tokens.get(1));
     assertEquals("c", tokens.get(2));
+  }
 
-    tokens = _csv.parse("a,\"b b\",\"c,c\"");
+  @Test
+  void testParseQuotedLettersWithComma() {
+    List<String> tokens = _csv.parse("a,\"b b\",\"c,c\"");
     assertEquals(3, tokens.size());
     assertEquals("a", tokens.get(0));
     assertEquals("b b", tokens.get(1));
     assertEquals("c,c", tokens.get(2));
+  }
 
-    tokens = _csv.parse("b\"b");
+  @Test
+  void testParseQuotedLettersWithEscapedDoubleQuote() {
+    List<String> tokens = _csv.parse("b\"b");
     assertEquals(1, tokens.size());
     assertEquals("b\"b", tokens.get(0));
+  }
+
+  @Test
+  void testParseQuotesWithEscapedDoubleQuoteAndUnexpectedTrailingChars() {
+    try {
+      _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck\" is expensive");
+      fail();
+    } catch(Exception e) {
+
+    }
+  }
+
+  @Test
+  void testParseQuotesWithUnexpectedTrailingChars() {
+    try {
+      _csv.parse("1997,Ford,E350,\"Super truck\" is expensive");
+      fail();
+    } catch(Exception e) {
+
+    }
   }
 
   @Test
@@ -113,23 +139,114 @@ class CSVLibraryTest {
   }
 
   @Test
-  void testTrimInitialWhitespace() {
-
-    _csv.setTrimInitialWhitespace(true);
-
-    List<String> tokens = _csv.parse(" \"g\" ");
-    assertEquals("g ", tokens.get(0));
-
-    tokens = _csv.parse(" \" h \" ");
-    assertEquals(" h  ", tokens.get(0));
-
-    tokens = _csv.parse(" \" \"\" i \"\" \" ");
-    assertEquals(" \" i \"  ", tokens.get(0));
-
-    tokens = _csv.parse(" \"a,b\",  c,  \"d\"");
-    assertEquals(3, tokens.size());
-    assertEquals("a,b", tokens.get(0));
-    assertEquals("c", tokens.get(1));
-    assertEquals("d", tokens.get(2));
+  void testParseEmptyString() {
+    List<String> tokens = _csv.parse("");
+    assertEquals(1, tokens.size());
+    assertEquals("", tokens.get(0));
   }
+
+  @Test
+  void testParseEmptyWhitespaceString() {
+    List<String> tokens = _csv.parse("  ");
+    assertEquals(1, tokens.size());
+    assertEquals("  ", tokens.get(0));
+  }
+
+  @Test
+  void testParseEmptyColumsString() {
+    List<String> tokens = _csv.parse(",,");
+    assertEquals(3, tokens.size());
+    assertEquals("", tokens.get(0));
+    assertEquals("", tokens.get(1));
+    assertEquals("", tokens.get(2));
+  }
+
+  @Test
+  void testParseEmptyColumsWhitespaceString() {
+    List<String> tokens = _csv.parse("  ,  ,  ");
+    assertEquals(3, tokens.size());
+    assertEquals("  ", tokens.get(0));
+    assertEquals("  ", tokens.get(1));
+    assertEquals("  ", tokens.get(2));
+  }
+
+  @Test
+  void testParseOpenQuotedLastColumnFails() {
+    try {
+      _csv.parse("\"open");
+      fail();
+    } catch(Exception e) {
+
+    }
+  }
+
+  @Test
+  void testParseQuotedColumnFollowedByEmptyLastColumn() {
+    List<String> tokens = _csv.parse("\"column\",");
+    assertEquals(2, tokens.size());
+    assertEquals("column", tokens.get(0));
+    assertEquals("", tokens.get(1));
+  }
+
+  @Test
+  void testParseColumnFollowedByEmptyLastColumn() {
+    List<String> tokens = _csv.parse("column,");
+    assertEquals(2, tokens.size());
+    assertEquals("column", tokens.get(0));
+    assertEquals("", tokens.get(1));
+  }
+
+  @Test
+  void testParseQuotedColumnWithEscapedDoubleQuoteFollowedByEmptyLastColumn() {
+    List<String> tokens = _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck\",");
+    assertEquals(5, tokens.size());
+    assertEquals("1997", tokens.get(0));
+    assertEquals("Ford", tokens.get(1));
+    assertEquals("E350", tokens.get(2));
+    assertEquals("Super \"luxurious\" truck", tokens.get(3));
+    assertEquals("", tokens.get(4));
+  }
+
+  @Test
+  void testParseQuotedColumnWithBackToBackEscapedDoubleQuoteFollowedByEmptyLastColumn() {
+    List<String> tokens = _csv.parse("1997,Ford,E350,\"start\"\"middle\"\"\"\"end\",");
+    assertEquals(5, tokens.size());
+    assertEquals("1997", tokens.get(0));
+    assertEquals("Ford", tokens.get(1));
+    assertEquals("E350", tokens.get(2));
+    assertEquals("start\"middle\"\"end", tokens.get(3));
+    assertEquals("", tokens.get(4));
+  }
+
+  @Test
+  void testParseQuotedColumnWithBackToBackEscapedDoubleQuoteLastColumn() {
+    List<String> tokens = _csv.parse("1997,Ford,E350,\"start\"\"middle\"\"\"\"\"");
+    assertEquals(4, tokens.size());
+    assertEquals("1997", tokens.get(0));
+    assertEquals("Ford", tokens.get(1));
+    assertEquals("E350", tokens.get(2));
+    assertEquals("start\"middle\"\"", tokens.get(3));
+  }
+
+  @Test
+  void testParseQuotedColumnWithBackToBackEscapedDoubleQuoteFollowedByAnotherColumn() {
+    List<String> tokens = _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck\",\"luxurious\"");
+    assertEquals(5, tokens.size());
+    assertEquals("1997", tokens.get(0));
+    assertEquals("Ford", tokens.get(1));
+    assertEquals("E350", tokens.get(2));
+    assertEquals("Super \"luxurious\" truck", tokens.get(3));
+    assertEquals("luxurious", tokens.get(4));
+  }
+
+  @Test
+  void testParseOpenQuoteWithEscapes() {
+    try {
+      _csv.parse("1997,Ford,E350,\"Super \"\"luxurious\"\" truck");
+      fail();
+    } catch(Exception e) {
+
+    }
+  }
+
 }

--- a/onebusaway-csv-entities/src/test/java/org/onebusaway/csv_entities/DelimitedTextParserTest.java
+++ b/onebusaway-csv-entities/src/test/java/org/onebusaway/csv_entities/DelimitedTextParserTest.java
@@ -1,0 +1,117 @@
+package org.onebusaway.csv_entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DelimitedTextParserTest {
+
+  private static class CsvColumn {
+
+    private String encoded;
+    private String decoded;
+
+    public CsvColumn(String encoded, String decoded) {
+      super();
+      this.encoded = encoded;
+      this.decoded = decoded;
+    }
+
+  }
+
+  private List<CsvColumn> columns;
+
+  @BeforeEach
+  protected void setup() {
+    List<CsvColumn> columns = new ArrayList<>();
+
+    columns.add(new CsvColumn("abcdef", "abcdef"));
+    columns.add(new CsvColumn("", ""));
+    columns.add(new CsvColumn("\"\"", ""));
+    columns.add(new CsvColumn("\"\"\"quoted value\"\"\"", "\"quoted value\""));
+    columns.add(new CsvColumn("\"Pre \"\"quoted value\"\"\"", "Pre \"quoted value\""));
+    columns.add(new CsvColumn("\"Pre \"\"quoted value\"\" post\"", "Pre \"quoted value\" post"));
+    columns.add(new CsvColumn("\"\"\"quoted value\"\" post\"", "\"quoted value\" post"));
+
+    this.columns = columns;
+  }
+
+  @Test
+  void testParseValidCsv() {
+    iterate(columns.toArray(new CsvColumn[columns.size()]), (elements) -> {
+      List<String> outputColumns = DelimitedTextParser.parse(toLine(elements));
+      assertEquals(outputColumns.size(), elements.length);
+      for (int i = 0; i < outputColumns.size(); i++) {
+        assertEquals(outputColumns.get(i), elements[i].decoded);
+      }
+    });
+  }
+
+  @Test
+  void testParseInvalidCsv() {
+    // add invalid columns
+    columns.add(new CsvColumn("\"open quote",  null));
+    columns.add(new CsvColumn("\"open quoute with escape\"\"", null));
+
+    iterate(columns.toArray(new CsvColumn[columns.size()]), (elements) -> {
+      try {
+        List<String> outputColumns = DelimitedTextParser.parse(toLine(elements));
+        for (int i = 0; i < outputColumns.size(); i++) {
+          assertEquals(outputColumns.get(i), elements[i].decoded);
+        }
+        Assertions.fail();
+      } catch(Exception e) {
+
+      }
+    });
+  }
+
+  public void iterate(CsvColumn[] elements, Consumer<CsvColumn[]> consumer) {
+    // iterate over all possible permutations of the input elements
+    // see https://www.baeldung.com/java-array-permutations
+    int n = elements.length;
+    int[] indexes = new int[n];
+    for (int i = 0; i < n; i++) {
+      indexes[i] = 0;
+    }
+
+    consumer.accept(elements);
+
+    int i = 0;
+    while (i < n) {
+      if (indexes[i] < i) {
+        swap(elements, i % 2 == 0 ?  0: indexes[i], i);
+        consumer.accept(elements);
+        indexes[i]++;
+        i = 0;
+      }
+      else {
+        indexes[i] = 0;
+        i++;
+      }
+    }
+  }
+
+  private static <T> void swap(CsvColumn[] elements, int a, int b) {
+    CsvColumn tmp = elements[a];
+    elements[a] = elements[b];
+    elements[b] = tmp;
+  }
+
+  private static String toLine(CsvColumn[] elements) {
+    StringBuilder builder = new StringBuilder();
+    for(CsvColumn column: elements) {
+      builder.append(column.encoded);
+      builder.append(",");
+    }
+    builder.setLength(builder.length() - 1);
+    return builder.toString();
+  }
+
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
@@ -107,7 +107,6 @@ public class GtfsReader extends CsvEntityReader {
     _entityClasses.add(Network.class);
 
     CsvTokenizerStrategy tokenizerStrategy = new CsvTokenizerStrategy();
-    tokenizerStrategy.getCsvParser().setTrimInitialWhitespace(true);
     setTokenizerStrategy(tokenizerStrategy);
     
     setTrimValues(true);

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsReaderTest.java
@@ -955,7 +955,7 @@ public class GtfsReaderTest extends BaseGtfsTest {
 
     StringBuilder b = new StringBuilder();
     b.append("agency_id,route_id,route_short_name,route_long_name,route_type\n");
-    b.append("        1,    R-10,              10,   \"Ten, Ten\",3\n");
+    b.append("1,R-10,10,\"Ten, Ten\",3\n");
     reader.readEntities(Route.class, new StringReader(b.toString()));
     Route route = reader.getEntityStore().getEntityForId(Route.class,
         new AgencyAndId("1", "R-10"));

--- a/onebusaway-jmh/README.md
+++ b/onebusaway-jmh/README.md
@@ -3,6 +3,6 @@ This module includes a few JMH benchmarks. Run
 
 Note: Remember to turn off CPU boost.
 
-> mvn clean package && java -jar target/jmh-benchmarks.jar GtfsBenchmark -rf json
+> mvn clean package && java -jar target/jmh-benchmarks.jar
 
 Use a visualizer like [JMH visualizer](https://jmh.morethan.io/) to drill down on the numbers.

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/BenchmarkMain.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/BenchmarkMain.java
@@ -2,8 +2,10 @@ package org.onebusaway.jmh;
 
 import java.time.Instant;
 
+import org.onebusaway.jmh.csv.CsvLineParserBenchmark;
 import org.onebusaway.jmh.csv.CsvParserBenchmark;
-import org.onebusaway.jmh.gtfs.GtfsBenchmark;
+import org.onebusaway.jmh.gtfs.GtfsSingleShotBenchmark;
+import org.onebusaway.jmh.gtfs.GtfsThroughputBenchmark;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -15,7 +17,9 @@ public class BenchmarkMain {
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
         .include(CsvParserBenchmark.class.getSimpleName())
-        .include(GtfsBenchmark.class.getSimpleName())
+        .include(GtfsThroughputBenchmark.class.getSimpleName())
+        .include(GtfsSingleShotBenchmark.class.getSimpleName())
+        .include(CsvLineParserBenchmark.class.getSimpleName())
         .result("jmh-result-" + Instant.now().toString() + ".json")
         .resultFormat(ResultFormatType.JSON)
         .build();

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/csv/CsvLineParserBenchmark.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/csv/CsvLineParserBenchmark.java
@@ -1,0 +1,151 @@
+package org.onebusaway.jmh.csv;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.onebusaway.csv_entities.DelimitedTextParser;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(time=3, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Measurement(time=3, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Timeout(timeUnit=TimeUnit.SECONDS, time=10)
+public class CsvLineParserBenchmark {
+
+  private final LegacyDelimitedTextParser legacyDelimitedTextParser = new LegacyDelimitedTextParser(',');
+  private final LegacyDelimitedTextParser skipWhitespaceLegacyDelimitedTextParser = new LegacyDelimitedTextParser(',');
+
+  public CsvLineParserBenchmark() {
+    skipWhitespaceLegacyDelimitedTextParser.setTrimInitialWhitespace(true);
+  }
+  
+  @State(Scope.Thread)
+  public static class ThreadState {
+    private List<String> stopTimes = new ArrayList<>();
+    private List<String> trips = new ArrayList<>();
+    
+    public ThreadState() {
+      try {
+        byte[] stopTimes = IOUtils.resourceToByteArray("/brown-county-flex/stop_times.txt");
+        this.stopTimes = toLines(stopTimes);
+
+        byte[] trips = IOUtils.resourceToByteArray("/turlock-fares-v2/trips.txt");
+        this.trips = toLines(trips);
+
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private List<String> toLines(byte[] stopTimes) throws IOException {
+      BufferedReader stopTimesReader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(stopTimes)));
+      
+      List<String> list = new ArrayList<>();
+      
+      String line;
+      while ((line = stopTimesReader.readLine()) != null) {
+        list.add(line);
+      }
+      stopTimesReader.close();
+      return list;
+    }
+  }
+  
+  @Benchmark
+  public int testParseStopTimes(ThreadState state) throws Exception {
+    int count = 0;
+    List<String> tokens = new ArrayList<>(22);
+    
+    for(String line : state.stopTimes) {
+      DelimitedTextParser.parse(line, tokens);
+      count += tokens.size();
+      tokens.clear();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int testParseTrips(ThreadState state) throws Exception {
+    int count = 0;
+    List<String> tokens = new ArrayList<>(20);
+    for(String line : state.trips) {
+      DelimitedTextParser.parse(line, tokens);
+      count += tokens.size();
+      tokens.clear();
+    }
+    return count;
+  }
+ 
+  @Benchmark
+  public int testParseStopTimesLegacy(ThreadState state) throws Exception {
+    int count = 0;
+    for(int i = 0; i < 1; i++) {
+      for(String line : state.stopTimes) {
+        count += legacyDelimitedTextParser.parse(line).size();
+      }
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int testParseTripsLegacy(ThreadState state) throws Exception {
+    int count = 0;
+    for(int i = 0; i < 1; i++) {
+      for(String line : state.trips) {
+        count += legacyDelimitedTextParser.parse(line).size();
+      }
+      count++;
+    }
+    return count;
+  }
+  
+  @Benchmark
+  public int testParseStopTimesSkipWhitespaceLegacy(ThreadState state) throws Exception {
+    int count = 0;
+    for(int i = 0; i < 1; i++) {
+      for(String line : state.stopTimes) {
+        count += skipWhitespaceLegacyDelimitedTextParser.parse(line).size();
+      }
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int testParseTripsSkipWhitespaceLegacy(ThreadState state) throws Exception {
+    int count = 0;
+    for(int i = 0; i < 1; i++) {
+      for(String line : state.trips) {
+        count += skipWhitespaceLegacyDelimitedTextParser.parse(line).size();
+      }
+      count++;
+    }
+    return count;
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(CsvLineParserBenchmark.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+}

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/csv/LegacyDelimitedTextParser.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/csv/LegacyDelimitedTextParser.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.jmh.csv;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Why do we have our own parser for CSV-like data when there are a couple of
+ * existing Java libraries? Mostly because we need to be able to handle some
+ * malformed CSV that most parsers would choke on but that agencies produce and
+ * google seems to validate as well.
+ * 
+ * @author bdferris
+ * 
+ */
+public class LegacyDelimitedTextParser {
+
+  private enum EParseState {
+    TRIM_INIT_WHITESPACE, DATA, DATA_IN_QUOTES, END_QUOTE
+  }
+
+  private final char _delimiter;
+
+  private boolean _trimInitialWhitespace = false;
+
+  public LegacyDelimitedTextParser(char delimiter) {
+    _delimiter = delimiter;
+  }
+
+  public void setTrimInitialWhitespace(boolean trimInitialWhitespace) {
+    _trimInitialWhitespace = trimInitialWhitespace;
+  }
+
+  public final List<String> parse(String line) {
+
+    StringBuilder token = new StringBuilder();
+    List<StringBuilder> tokens = new ArrayList<StringBuilder>();
+    if (line.length() > 0)
+      tokens.add(token);
+
+    EParseState resetState = _trimInitialWhitespace
+        ? EParseState.TRIM_INIT_WHITESPACE : EParseState.DATA;
+    EParseState state = resetState;
+
+    for (int i = 0; i < line.length(); i++) {
+      char c = line.charAt(i);
+      switch (state) {
+        case TRIM_INIT_WHITESPACE:
+          if (c == _delimiter) {
+            token = new StringBuilder();
+            tokens.add(token);
+          } else {
+            switch (c) {
+              case ' ':
+                break;
+              case '"':
+                if (token.length() == 0)
+                  state = EParseState.DATA_IN_QUOTES;
+                else
+                  token.append(c);
+                break;
+              default:
+                state = EParseState.DATA;
+                token.append(c);
+                break;
+            }
+          }
+          break;
+        case DATA:
+          if (c == _delimiter) {
+            token = new StringBuilder();
+            tokens.add(token);
+            state = resetState;
+          } else {
+            switch (c) {
+              case '"':
+                if (token.length() == 0)
+                  state = EParseState.DATA_IN_QUOTES;
+                else
+                  token.append(c);
+                break;
+              default:
+                token.append(c);
+                break;
+            }
+          }
+          break;
+        case DATA_IN_QUOTES:
+          switch (c) {
+            case '"':
+              state = EParseState.END_QUOTE;
+              break;
+            default:
+              token.append(c);
+              break;
+          }
+          break;
+        case END_QUOTE:
+          if (c == _delimiter) {
+            token = new StringBuilder();
+            tokens.add(token);
+            state = resetState;
+            break;
+          } else {
+            switch (c) {
+              case '"':
+                token.append('"');
+                state = EParseState.DATA_IN_QUOTES;
+                break;
+              default:
+                token.append(c);
+                state = EParseState.DATA;
+                break;
+            }
+          }
+          break;
+      }
+    }
+    List<String> retro = new ArrayList<String>(tokens.size());
+    for (StringBuilder b : tokens)
+      retro.add(b.toString());
+    return retro;
+  }
+}

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsThroughputBenchmark.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/GtfsThroughputBenchmark.java
@@ -1,0 +1,72 @@
+package org.onebusaway.jmh.gtfs;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.serialization.GtfsReader;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Fork(value = 10) //, jvmArgs= {"-XX:+UnlockDiagnosticVMOptions", "-Xlog:class+load=info", "-XX:+LogCompilation", "-XX:+DebugNonSafepoints"})
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(time=10, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Measurement(time=10, timeUnit=TimeUnit.SECONDS, iterations=1)
+@Timeout(timeUnit=TimeUnit.SECONDS, time=1000)
+public class GtfsThroughputBenchmark {
+
+  @State(Scope.Thread)
+  public static class ThreadState {
+    GtfsReader reader = new GtfsReader();
+    public ThreadState() {
+      reader.setOverwriteDuplicates(true);
+    }
+  }
+
+  @Benchmark
+  public GtfsRelationalDao testParse(ThreadState state) throws Exception {
+    return processFeed(new File("./src/main/resources/island-transit_20090312_0314"), "abcd", false, state.reader);
+  }
+
+  public static GtfsRelationalDao processFeed(
+      File resourcePath, String agencyId,
+      boolean internStrings, GtfsReader reader
+      ) throws IOException {
+
+    GtfsRelationalDaoImpl entityStore = new GtfsRelationalDaoImpl();
+    entityStore.setGenerateIds(true);
+
+    reader.setDefaultAgencyId(agencyId);
+    reader.setInternStrings(internStrings);
+
+    reader.setInputLocation(resourcePath);
+    
+    try {
+      reader.run();
+      return entityStore;
+    } finally {
+      entityStore.clearAllCaches();
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(GtfsThroughputBenchmark.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+}

--- a/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/ParseStopTimeBenchmark.java
+++ b/onebusaway-jmh/src/main/java/org/onebusaway/jmh/gtfs/ParseStopTimeBenchmark.java
@@ -40,10 +40,9 @@ public class ParseStopTimeBenchmark {
       try {
         BufferedReader r = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream("/brown-county-flex/stop_times.txt")));
         String line = null;
-        DelimitedTextParser parser = new DelimitedTextParser(',');
         r.readLine(); // skip first line
         while ((line = r.readLine()) != null) {
-          List<String> values = parser.parse(line);
+          List<String> values = DelimitedTextParser.parse(line);
           String string = values.get(values.size() - 6);
           if(string.length() > 0) {
             time.add(values.get(values.size() - 6));


### PR DESCRIPTION
**Summary:**
Rewrite CSV-line-parser for improved performance. Added tests to cover various new code paths.

Added CSV-line-parser benchmark + adjusted some other benchmarks.

Functional changes:
 * Reusing ArrayList in `parseLine(..)` when reading many lines.
 * removed skip whitespace option
 * blow up if any characters between end quote and divider
 
**Expected behavior:** 
Better performance:

```
Benchmark                                                       Mode  Cnt   Score   Error   Units
CsvLineParserBenchmark.testParseStopTimes                      thrpt    5  12,795 ± 0,436  ops/ms
CsvLineParserBenchmark.testParseStopTimesLegacy                thrpt    5   3,625 ± 0,095  ops/ms
CsvLineParserBenchmark.testParseStopTimesSkipWhitespaceLegacy  thrpt    5   1,779 ± 0,021  ops/ms
CsvLineParserBenchmark.testParseTrips                          thrpt    5  15,848 ± 0,284  ops/ms
CsvLineParserBenchmark.testParseTripsLegacy                    thrpt    5   3,249 ± 0,031  ops/ms
CsvLineParserBenchmark.testParseTripsSkipWhitespaceLegacy      thrpt    5   1,760 ± 0,043  ops/ms
```

https://github.com/OneBusAway/onebusaway-gtfs-modules/issues/352

- [x] Linked all relevant issues
