### PR TITLE
Fix transformer regex escaping for replacements

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/deferred/ReplaceValueSetter.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/deferred/ReplaceValueSetter.java
@@ -37,9 +37,14 @@ public class ReplaceValueSetter implements ValueSetter {
     String updatedValue = stringValue.replaceAll(matchRegex, replacementValue);
     if (!stringValue.equals(updatedValue)) {
       if (bean.getPropertyType(propertyName) == AgencyAndId.class) {
-        AgencyAndId aid = (AgencyAndId) bean.getPropertyValue(propertyName);
-        aid.setId(updatedValue);
-        bean.setPropertyValue(propertyName, aid);
+        if (updatedValue.indexOf(AgencyAndId.ID_SEPARATOR) != -1) {
+          AgencyAndId parsed = AgencyAndId.convertFromString(updatedValue);
+          bean.setPropertyValue(propertyName, parsed);
+        } else {
+          AgencyAndId aid = (AgencyAndId) bean.getPropertyValue(propertyName);
+          aid.setId(updatedValue);
+          bean.setPropertyValue(propertyName, aid);
+        }
       } else {
         bean.setPropertyValue(propertyName, updatedValue);
       }

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/factory/TransformFactoryTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/factory/TransformFactoryTest.java
@@ -178,6 +178,51 @@ public class TransformFactoryTest {
   }
 
   @Test
+  public void testReplaceValueWithEscapedSlash()
+      throws IOException, TransformSpecificationException {
+    _factory.addModificationsFromString(
+        "{'op':'update', "
+            + "'match':{'file':'trips.txt'}, "
+            + "'update':{'trip_id': 's/foo\\/bar/baz/'}}");
+
+    GtfsTransformStrategy transform = _transformer.getLastTransform();
+    TransformContext context = new TransformContext();
+    context.setDefaultAgencyId("3");
+    GtfsMutableRelationalDao dao = new GtfsRelationalDaoImpl();
+
+    Trip trip = new Trip();
+    trip.setId(new AgencyAndId("3", "foo/bar"));
+    dao.saveEntity(trip);
+
+    transform.run(context, dao);
+
+    assertEquals("baz", trip.getId().getId());
+  }
+
+  @Test
+  public void testReplaceValueWithEscapedSlashRouteUrl()
+      throws IOException, TransformSpecificationException {
+    _factory.addModificationsFromString(
+        "{'op':'update', "
+            + "'match':{'file':'routes.txt'}, "
+            + "'update':{'route_url': 's/foo\\/bar/baz/'}}");
+
+    GtfsTransformStrategy transform = _transformer.getLastTransform();
+    TransformContext context = new TransformContext();
+    context.setDefaultAgencyId("4");
+    GtfsMutableRelationalDao dao = new GtfsRelationalDaoImpl();
+
+    Route route = new Route();
+    route.setId(new AgencyAndId("4", "route1"));
+    route.setUrl("https://example.com/foo/bar");
+    dao.saveEntity(route);
+
+    transform.run(context, dao);
+
+    assertEquals("https://example.com/baz", route.getUrl());
+  }
+
+  @Test
   public void testCalendarSimplification() throws IOException, TransformSpecificationException {
     _factory.addModificationsFromString("{'op':'calendar_simplification'}");
     GtfsTransformStrategy transform = _transformer.getLastTransform();


### PR DESCRIPTION
## Summary
- allow escaped `/` characters in `s///` specs by tightening the matcher and unescaping capture groups before building `ReplaceValueSetter`
- ensure `ReplaceValueSetter` handles both `AgencyAndId` values and plain fields correctly when underscores remain
- add regression tests covering escaped replacements for trip IDs and route URLs
