### PR TITLE
Fix `BookingRule` appearing twice

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
@@ -59,7 +59,6 @@ public class GtfsEntitySchemaFactory {
     entityClasses.add(Pathway.class);
     entityClasses.add(Transfer.class);
     entityClasses.add(Ridership.class);
-    entityClasses.add(BookingRule.class);
     entityClasses.add(Vehicle.class);
     entityClasses.add(Facility.class);
     entityClasses.add(FacilityPropertyDefinition.class);

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactoryTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactoryTest.java
@@ -1,0 +1,21 @@
+package org.onebusaway.gtfs.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class GtfsEntitySchemaFactoryTest {
+
+  @Test
+  public void testGetEntityClassesHasNoDuplicates() {
+    List<Class<?>> classes = GtfsEntitySchemaFactory.getEntityClasses();
+    Set<Class<?>> seen = new HashSet<>();
+    List<Class<?>> duplicates =
+        classes.stream().filter(c -> !seen.add(c)).collect(Collectors.toList());
+    assertEquals(List.of(), duplicates, "getEntityClasses() must not contain duplicate entries");
+  }
+}

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactoryTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactoryTest.java
@@ -1,6 +1,6 @@
 package org.onebusaway.gtfs.serialization;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
@@ -16,6 +16,8 @@ public class GtfsEntitySchemaFactoryTest {
     Set<Class<?>> seen = new HashSet<>();
     List<Class<?>> duplicates =
         classes.stream().filter(c -> !seen.add(c)).collect(Collectors.toList());
-    assertEquals(List.of(), duplicates, "getEntityClasses() must not contain duplicate entries");
+    assertTrue(
+        duplicates.isEmpty(),
+        "getEntityClasses() must not contain duplicate entries: " + duplicates);
   }
 }

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactoryTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactoryTest.java
@@ -1,6 +1,6 @@
 package org.onebusaway.gtfs.serialization;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.HashSet;
 import java.util.List;
@@ -16,8 +16,6 @@ public class GtfsEntitySchemaFactoryTest {
     Set<Class<?>> seen = new HashSet<>();
     List<Class<?>> duplicates =
         classes.stream().filter(c -> !seen.add(c)).collect(Collectors.toList());
-    assertTrue(
-        duplicates.isEmpty(),
-        "getEntityClasses() must not contain duplicate entries: " + duplicates);
+    assertThat(duplicates).isEmpty();
   }
 }


### PR DESCRIPTION
**Summary:**

Fix `BookingRule` appearing twice and add test for duplicates



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test that validates the GTFS entity schema contains no duplicate entity entries, improving confidence in data integrity and preventing subtle runtime issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->