### PR TITLE
Add support for writing GeoJSON files 

### DIFF
--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CsvEntityWriter.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CsvEntityWriter.java
@@ -69,4 +69,8 @@ public class CsvEntityWriter implements EntityHandler {
   public void close() throws IOException {
     _outputStrategy.close();
   }
+
+  protected void writeRawEntry(String filename, String content) throws IOException {
+    _outputStrategy.writeRawEntry(filename, content);
+  }
 }

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/FileOutputStrategy.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/FileOutputStrategy.java
@@ -57,6 +57,15 @@ class FileOutputStrategy implements OutputStrategy {
   }
 
   @Override
+  public void writeRawEntry(String filename, String content) throws IOException {
+    if (!_outputDirectory.exists()) _outputDirectory.mkdirs();
+    File outputFile = new File(_outputDirectory, filename);
+    try (PrintWriter writer = new PrintWriter(outputFile, "UTF-8")) {
+      writer.write(content);
+    }
+  }
+
+  @Override
   public void flush() {
     for (IndividualCsvEntityWriter writer : _writersByType.values()) writer.flush();
   }

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/OutputStrategy.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/OutputStrategy.java
@@ -30,4 +30,6 @@ interface OutputStrategy {
   public void flush() throws IOException;
 
   public void close() throws IOException;
+
+  public void writeRawEntry(String filename, String content) throws IOException;
 }

--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/ZipOutputStrategy.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/ZipOutputStrategy.java
@@ -91,6 +91,15 @@ class ZipOutputStrategy implements OutputStrategy {
   }
 
   @Override
+  public void writeRawEntry(String filename, String content) throws IOException {
+    closeCurrentEntityWriter();
+    _out.putNextEntry(new ZipEntry(filename));
+    _writer.write(content);
+    _writer.flush();
+    _out.closeEntry();
+  }
+
+  @Override
   public void flush() throws IOException {
     _out.flush();
   }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
@@ -42,6 +42,7 @@ public class GtfsEntitySchemaFactory {
     entityClasses.add(Level.class);
     entityClasses.add(Stop.class);
     entityClasses.add(StopAreaElement.class);
+    entityClasses.add(Location.class);
     entityClasses.add(LocationGroup.class);
     entityClasses.add(LocationGroupElement.class);
     entityClasses.add(Trip.class);

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsWriter.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsWriter.java
@@ -15,6 +15,7 @@ package org.onebusaway.gtfs.serialization;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.onebusaway.csv_entities.CsvEntityWriter;
 import org.onebusaway.csv_entities.schema.DefaultEntitySchemaFactory;
+import org.onebusaway.gtfs.model.Location;
 import org.onebusaway.gtfs.services.GtfsDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,14 +68,27 @@ public class GtfsWriter extends CsvEntityWriter {
 
     for (Class<?> entityClass : classes) {
       _log.info("writing entities: " + entityClass.getName());
-      Collection<Object> entities =
-          sortEntities(entityClass, dao.getAllEntitiesForType(entityClass));
-      excludeOptionalAndMissingFields(entityClass, entities);
-      for (Object entity : entities) handleEntity(entity);
-      flush();
+      if (entityClass == Location.class) {
+        writeLocations(dao);
+      } else {
+        Collection<Object> entities =
+            sortEntities(entityClass, dao.getAllEntitiesForType(entityClass));
+        excludeOptionalAndMissingFields(entityClass, entities);
+        for (Object entity : entities) handleEntity(entity);
+        flush();
+      }
     }
 
     close();
+  }
+
+  private void writeLocations(GtfsDao dao) throws IOException {
+    Collection<Location> locations = dao.getAllEntitiesForType(Location.class);
+    if (locations.isEmpty()) return;
+
+    StringWriter sw = new StringWriter();
+    new LocationsGeoJSONWriter(sw).write(locations);
+    writeRawEntry("locations.geojson", sw.toString());
   }
 
   @SuppressWarnings("unchecked")

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReader.java
@@ -47,7 +47,7 @@ public class LocationsGeoJSONReader {
       location.setId(new AgencyAndId(this.defaultAgencyId, feature.getId()));
       location.setGeometry(feature.getGeometry());
       location.setName((String) feature.getProperties().get("stop_name"));
-      location.setDescription((String) feature.getProperties().get("stop_description"));
+      location.setDescription((String) feature.getProperties().get("stop_desc"));
       location.setUrl((String) feature.getProperties().get("stop_url"));
       location.setZoneId((String) feature.getProperties().get("zone_id"));
       locations.add(location);

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriter.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriter.java
@@ -31,8 +31,7 @@ public class LocationsGeoJSONWriter {
 
       Map<String, Object> properties = new HashMap<>();
       if (location.getName() != null) properties.put("stop_name", location.getName());
-      if (location.getDescription() != null)
-        properties.put("stop_description", location.getDescription());
+      if (location.getDescription() != null) properties.put("stop_desc", location.getDescription());
       if (location.getUrl() != null) properties.put("stop_url", location.getUrl());
       if (location.getZoneId() != null) properties.put("zone_id", location.getZoneId());
       feature.setProperties(properties);

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriter.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriter.java
@@ -1,0 +1,45 @@
+package org.onebusaway.gtfs.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.geojson.Feature;
+import org.geojson.FeatureCollection;
+import org.onebusaway.gtfs.model.Location;
+
+public class LocationsGeoJSONWriter {
+
+  private static final ObjectWriter OBJECT_WRITER = new ObjectMapper().writer();
+
+  private final Writer writer;
+
+  public LocationsGeoJSONWriter(Writer writer) {
+    this.writer = writer;
+  }
+
+  public void write(Collection<Location> locations) throws IOException {
+    FeatureCollection featureCollection = new FeatureCollection();
+
+    for (Location location : locations) {
+      Feature feature = new Feature();
+      feature.setId(location.getId().getId());
+      feature.setGeometry(location.getGeometry());
+
+      Map<String, Object> properties = new HashMap<>();
+      if (location.getName() != null) properties.put("stop_name", location.getName());
+      if (location.getDescription() != null)
+        properties.put("stop_description", location.getDescription());
+      if (location.getUrl() != null) properties.put("stop_url", location.getUrl());
+      if (location.getZoneId() != null) properties.put("zone_id", location.getZoneId());
+      feature.setProperties(properties);
+
+      featureCollection.add(feature);
+    }
+
+    OBJECT_WRITER.writeValue(writer, featureCollection);
+  }
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriter.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriter.java
@@ -13,7 +13,8 @@ import org.onebusaway.gtfs.model.Location;
 
 public class LocationsGeoJSONWriter {
 
-  private static final ObjectWriter OBJECT_WRITER = new ObjectMapper().writer();
+  private static final ObjectWriter OBJECT_WRITER =
+      new ObjectMapper().writerWithDefaultPrettyPrinter();
 
   private final Writer writer;
 

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONRoundTripTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONRoundTripTest.java
@@ -1,0 +1,94 @@
+package org.onebusaway.gtfs.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.GtfsTestData;
+import org.onebusaway.gtfs.impl.FileSupport;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.model.Location;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+
+public class LocationsGeoJSONRoundTripTest {
+
+  private FileSupport _support = new FileSupport();
+  private File _tmpDirectory;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    _tmpDirectory = File.createTempFile("LocationsGeoJSONRoundTripTest-", "-tmp");
+    if (_tmpDirectory.exists()) _support.deleteFileRecursively(_tmpDirectory);
+    _tmpDirectory.mkdirs();
+    _support.markForDeletion(_tmpDirectory);
+  }
+
+  @AfterEach
+  public void teardown() {
+    _support.cleanup();
+  }
+
+  @Test
+  public void roundTripToDirectory() throws IOException {
+    File input = GtfsTestData.getPierceTransitFlex();
+    GtfsRelationalDao original = readFeed(input, "1");
+
+    Collection<Location> originalLocations = original.getAllLocations();
+    assertTrue(originalLocations.size() > 0, "Expected at least one Location in test feed");
+
+    GtfsWriter writer = new GtfsWriter();
+    writer.setOutputLocation(_tmpDirectory);
+    writer.run(original);
+
+    GtfsRelationalDao reread = readFeed(_tmpDirectory, "1");
+
+    assertLocationsEqual(originalLocations, reread);
+  }
+
+  @Test
+  public void roundTripToZip() throws IOException {
+    File input = GtfsTestData.getPierceTransitFlex();
+    GtfsRelationalDao original = readFeed(input, "1");
+
+    Collection<Location> originalLocations = original.getAllLocations();
+    assertTrue(originalLocations.size() > 0, "Expected at least one Location in test feed");
+
+    File zipOut = new File(_tmpDirectory, "output.zip");
+    GtfsWriter writer = new GtfsWriter();
+    writer.setOutputLocation(zipOut);
+    writer.run(original);
+
+    GtfsRelationalDao reread = readFeed(zipOut, "1");
+
+    assertLocationsEqual(originalLocations, reread);
+  }
+
+  private static void assertLocationsEqual(
+      Collection<Location> originalLocations, GtfsRelationalDao reread) {
+    assertEquals(originalLocations.size(), reread.getAllLocations().size());
+    for (Location expected : originalLocations) {
+      Location actual = reread.getEntityForId(Location.class, expected.getId());
+      assertEquals(expected.getId().getId(), actual.getId().getId());
+      assertEquals(expected.getName(), actual.getName());
+      assertEquals(expected.getDescription(), actual.getDescription());
+      assertEquals(expected.getUrl(), actual.getUrl());
+      assertEquals(expected.getZoneId(), actual.getZoneId());
+      assertEquals(expected.getGeometry(), actual.getGeometry());
+    }
+  }
+
+  private static GtfsRelationalDao readFeed(File path, String defaultAgencyId) throws IOException {
+    GtfsReader reader = new GtfsReader();
+    reader.setDefaultAgencyId(defaultAgencyId);
+    reader.setInputLocation(path);
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+    reader.setEntityStore(dao);
+    reader.run();
+    return dao;
+  }
+}

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriterTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONWriterTest.java
@@ -1,0 +1,73 @@
+package org.onebusaway.gtfs.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.List;
+import org.geojson.LngLatAlt;
+import org.geojson.Polygon;
+import org.junit.jupiter.api.Test;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Location;
+
+public class LocationsGeoJSONWriterTest {
+
+  @Test
+  public void write() throws IOException {
+    Location location = new Location();
+    location.setId(new AgencyAndId("agency", "si_Wendenschlossstrasse"));
+    location.setName("Wendenschlossstrasse");
+    location.setDescription("A nice description");
+    location.setUrl("http://example.com");
+    location.setZoneId("fare-zone-A");
+    Polygon polygon =
+        new Polygon(
+            new LngLatAlt(13.576526641845703, 52.44413508398945),
+            new LngLatAlt(13.575839996337889, 52.429169943434495),
+            new LngLatAlt(13.590774536132812, 52.4105872618342),
+            new LngLatAlt(13.60879898071289, 52.43225757383383),
+            new LngLatAlt(13.576526641845703, 52.44413508398945));
+    location.setGeometry(polygon);
+
+    StringWriter sw = new StringWriter();
+    new LocationsGeoJSONWriter(sw).write(List.of(location));
+
+    Collection<Location> read =
+        new LocationsGeoJSONReader(new StringReader(sw.toString()), "agency").read();
+
+    assertEquals(1, read.size());
+    Location result = read.iterator().next();
+
+    assertEquals("si_Wendenschlossstrasse", result.getId().getId());
+    assertEquals("Wendenschlossstrasse", result.getName());
+    assertEquals("A nice description", result.getDescription());
+    assertEquals("http://example.com", result.getUrl());
+    assertEquals("fare-zone-A", result.getZoneId());
+    assertEquals(polygon, result.getGeometry());
+  }
+
+  @Test
+  public void writeOmitsNullProperties() throws IOException {
+    Location location = new Location();
+    location.setId(new AgencyAndId("agency", "loc1"));
+
+    StringWriter sw = new StringWriter();
+    new LocationsGeoJSONWriter(sw).write(List.of(location));
+
+    Collection<Location> read =
+        new LocationsGeoJSONReader(new StringReader(sw.toString()), "agency").read();
+
+    assertEquals(1, read.size());
+    Location result = read.iterator().next();
+
+    assertEquals("loc1", result.getId().getId());
+    assertEquals(null, result.getName());
+    assertEquals(null, result.getDescription());
+    assertEquals(null, result.getUrl());
+    assertEquals(null, result.getZoneId());
+    assertEquals(null, result.getGeometry());
+  }
+}

--- a/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/locations.geojson
+++ b/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/locations.geojson
@@ -7,7 +7,7 @@
       "id": "si_Wendenschlossstrasse",
       "properties": {
         "stop_name": "Wendenschlossstrasse",
-        "stop_description": "A nice description",
+        "stop_desc": "A nice description",
         "stop_url": "http://example.com",
         "zone_id": "fare-zone-A"
       },


### PR DESCRIPTION
**Summary:**

- Implement `LocationsGeoJSONWriter`
- Change `stop_description` to `stop_desc` (https://gtfs.org/documentation/schedule/reference/#locationsgeojson)

**Testing**

- Unit tests
- Manual testing
  - Generated output seems to work with OTP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Location data now exports to GeoJSON format (locations.geojson) with full geometry and property details alongside traditional CSV files
  * Added raw entry writing capability for flexible output customization

* **Improvements**
  * Standardized GeoJSON property naming conventions for location descriptions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/onebusaway-gtfs-modules/pull/456)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->