### PR TITLE
Parse experimental trip segments

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDaoImpl.java
@@ -255,6 +255,14 @@ public class GtfsDaoImpl extends GenericDaoImpl implements GtfsMutableDao {
     return getAllEntitiesForType(NoticeAssignment.class);
   }
 
+  public Collection<TripSegment> getAllTripSegments() {
+    return getAllEntitiesForType(TripSegment.class);
+  }
+
+  public TripSegment getTripSegmentForId(AgencyAndId id) {
+    return getEntityForId(TripSegment.class, id);
+  }
+
   public Facility getFacilityForId(AgencyAndId id) {
     return getEntityForId(Facility.class, id);
   }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/impl/GtfsDataServiceImpl.java
@@ -418,6 +418,16 @@ public class GtfsDataServiceImpl implements GtfsDataService {
   }
 
   @Override
+  public Collection<TripSegment> getAllTripSegments() {
+    return _dao.getAllTripSegments();
+  }
+
+  @Override
+  public TripSegment getTripSegmentForId(AgencyAndId id) {
+    return _dao.getTripSegmentForId(id);
+  }
+
+  @Override
   public List<Ridership> getRidershipForTrip(AgencyAndId tripId) {
     return _dao.getRidershipForTrip(tripId);
   }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/NoticeAssignment.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/NoticeAssignment.java
@@ -58,6 +58,7 @@ public final class NoticeAssignment extends IdentityBean<AgencyAndId> {
 
   public enum TableName {
     trips,
-    routes
+    routes,
+    trip_segments
   }
 }

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/TripSegment.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/TripSegment.java
@@ -1,0 +1,61 @@
+package org.onebusaway.gtfs.model;
+
+import org.onebusaway.csv_entities.schema.annotations.CsvField;
+import org.onebusaway.csv_entities.schema.annotations.CsvFields;
+import org.onebusaway.csv_entities.schema.annotations.Experimental;
+import org.onebusaway.gtfs.serialization.mappings.DefaultAgencyIdFieldMappingFactory;
+
+@CsvFields(filename = "trip_segments.txt", required = false)
+@Experimental(proposedBy = "https://github.com/google/transit/pull/638")
+public final class TripSegment extends IdentityBean<AgencyAndId> {
+
+  @CsvField(name = "trip_segment_id", mapping = DefaultAgencyIdFieldMappingFactory.class)
+  private AgencyAndId id;
+
+  @CsvField(name = "trip_id", mapping = DefaultAgencyIdFieldMappingFactory.class)
+  private AgencyAndId tripId;
+
+  @CsvField(name = "from_stop_sequence")
+  private int fromStopSequence;
+
+  @CsvField(name = "to_stop_sequence")
+  private int toStopSequence;
+
+  @Override
+  public AgencyAndId getId() {
+    return id;
+  }
+
+  @Override
+  public void setId(AgencyAndId id) {
+    this.id = id;
+  }
+
+  public AgencyAndId getTripId() {
+    return tripId;
+  }
+
+  public void setTripId(AgencyAndId tripId) {
+    this.tripId = tripId;
+  }
+
+  public int getFromStopSequence() {
+    return fromStopSequence;
+  }
+
+  public void setFromStopSequence(int fromStopSequence) {
+    this.fromStopSequence = fromStopSequence;
+  }
+
+  public int getToStopSequence() {
+    return toStopSequence;
+  }
+
+  public void setToStopSequence(int toStopSequence) {
+    this.toStopSequence = toStopSequence;
+  }
+
+  public String toString() {
+    return "<TripSegment " + getId() + ">";
+  }
+}

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsEntitySchemaFactory.java
@@ -68,6 +68,7 @@ public class GtfsEntitySchemaFactory {
     entityClasses.add(Icon.class);
     entityClasses.add(Network.class);
     entityClasses.add(Timeframe.class);
+    entityClasses.add(TripSegment.class);
     return entityClasses;
   }
 

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/GtfsReader.java
@@ -91,6 +91,7 @@ public class GtfsReader extends CsvEntityReader {
     _entityClasses.add(Network.class);
     _entityClasses.add(Notice.class);
     _entityClasses.add(NoticeAssignment.class);
+    _entityClasses.add(TripSegment.class);
     _entityClasses.add(Timeframe.class);
 
     CsvTokenizerStrategy tokenizerStrategy = new CsvTokenizerStrategy();

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/services/GtfsDao.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/services/GtfsDao.java
@@ -231,6 +231,14 @@ public interface GtfsDao extends GenericDao {
 
   Collection<NoticeAssignment> getAllNoticeAssignments();
 
+  /****
+   * {@link TripSegment} Methods
+   ****/
+
+  Collection<TripSegment> getAllTripSegments();
+
+  TripSegment getTripSegmentForId(AgencyAndId id);
+
   Collection<DirectionEntry> getAllDirectionEntries();
 
   default boolean hasFaresV1() {

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/NoticesTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/NoticesTest.java
@@ -37,7 +37,7 @@ class NoticesTest {
     var dao = processFeed(GtfsTestData.getVpeNotices(), AGENCY_ID, false);
 
     var assignments = dao.getAllNoticeAssignments();
-    assertEquals(46, assignments.size());
+    assertEquals(47, assignments.size());
 
     var routeAssignment =
         assignments.stream()
@@ -61,6 +61,20 @@ class NoticesTest {
             .findFirst()
             .orElseThrow();
     assertEquals(TableName.trips, tripAssignment.getTableName());
+  }
+
+  @Test
+  void tripSegmentsTest() throws IOException {
+    var dao = processFeed(GtfsTestData.getVpeNotices(), AGENCY_ID, false);
+
+    var segments = dao.getAllTripSegments();
+    assertEquals(1, segments.size());
+
+    var segment = dao.getTripSegmentForId(id("segment1"));
+    assertNotNull(segment);
+    assertEquals(id("de:vpe:de:vpe:04102_"), segment.getTripId());
+    assertEquals(2, segment.getFromStopSequence());
+    assertEquals(4, segment.getToStopSequence());
   }
 
   private static AgencyAndId id(String id) {

--- a/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/vpe-notices/notice_assignments.txt
+++ b/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/vpe-notices/notice_assignments.txt
@@ -45,3 +45,4 @@ de:ntid:5,,trips,de:vpe:de:vpe:04102_::2780
 de:ntid:5,,trips,de:vpe:de:vpe:04102_::2741
 de:ntid:5,,trips,de:vpe:de:vpe:04102_::2742
 de:ntid:5,,trips,de:vpe:de:vpe:04102_::2743
+de:ntid:5,,trip_segments,de:vpe:de:vpe:04102_::2743

--- a/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/vpe-notices/trip_segments.txt
+++ b/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/vpe-notices/trip_segments.txt
@@ -1,0 +1,2 @@
+trip_segment_id,trip_id,from_stop_sequence,to_stop_sequence
+segment1,de:vpe:de:vpe:04102_,2,4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for trip segments in GTFS data, including loading, storing, and looking up individual segments.
  * Trip segment records can now be included in notices and parsed from feed data.

* **Bug Fixes**
  * Updated GTFS notice handling to recognize the new trip segment table type.

* **Tests**
  * Added coverage for trip segment parsing and lookup, including expected trip and stop sequence details.
  * Updated existing notice assignment expectations to match the new data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->