### PR TITLE
Fix uppercase ZIP output handling

### DIFF
--- a/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CsvEntityWriter.java
+++ b/onebusaway-csv-entities/src/main/java/org/onebusaway/csv_entities/CsvEntityWriter.java
@@ -15,6 +15,7 @@ package org.onebusaway.csv_entities;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 import org.onebusaway.csv_entities.schema.DefaultEntitySchemaFactory;
 import org.onebusaway.csv_entities.schema.EntitySchemaFactory;
 import org.onebusaway.csv_entities.schema.ExcludeOptionalAndMissingEntitySchemaFactory;
@@ -38,7 +39,7 @@ public class CsvEntityWriter implements EntityHandler {
   }
 
   public void setOutputLocation(File path) {
-    if (path.getName().endsWith(".zip")) {
+    if (path.getName().toLowerCase(Locale.ROOT).endsWith(".zip")) {
       _outputStrategy = ZipOutputStrategy.create(path);
     } else {
       _outputStrategy = new FileOutputStrategy(path);

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/GtfsTransformer.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/GtfsTransformer.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.onebusaway.csv_entities.schema.DefaultEntitySchemaFactory;
 import org.onebusaway.gtfs.impl.GenericMutableDaoWrapper;
@@ -153,7 +154,8 @@ public class GtfsTransformer {
 
     if (_outputDirectory != null
         && !_outputDirectory.exists()
-        && !_outputDirectory.getName().endsWith(".zip")) _outputDirectory.mkdirs();
+        && !_outputDirectory.getName().toLowerCase(Locale.ROOT).endsWith(".zip"))
+      _outputDirectory.mkdirs();
 
     // copy over parameters
     for (String key : _parameters.keySet()) {

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/GtfsTransformerTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/GtfsTransformerTest.java
@@ -14,12 +14,18 @@
 package org.onebusaway.gtfs_transformer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.StopTime;
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
@@ -133,6 +139,21 @@ public class GtfsTransformerTest {
                 + "'update':{'continuous_pickup':'2'}}");
     StopTime next = dao.getAllStopTimes().iterator().next();
     assertEquals(2, next.getContinuousPickup());
+  }
+
+  @Test
+  public void testUppercaseZipOutput(@TempDir Path tempDir) throws Exception {
+    Path output = tempDir.resolve("output.ZIP");
+    _transformer.setGtfsInputDirectory(_gtfs.getPath());
+    _transformer.setOutputDirectory(output.toFile());
+
+    _transformer.run();
+
+    assertTrue(Files.isRegularFile(output));
+    assertFalse(Files.isDirectory(output));
+    try (ZipFile zipFile = new ZipFile(output.toFile())) {
+      assertNotNull(zipFile.getEntry("agency.txt"));
+    }
   }
 
   private GtfsRelationalDao transform(String transformSpec) throws Exception {


### PR DESCRIPTION
**Summary:**

Fixes #118.

- Fix uppercase `.ZIP` output handling in both `GtfsTransformer` and `CsvEntityWriter`.
- Add a regression test verifying that an uppercase `.ZIP` output is created as a valid ZIP archive containing `agency.txt`.

**Testing:**

- `mvn "-DskipTests" "-Dgpg.skip=true" -pl onebusaway-gtfs-transformer -am install`
- `mvn "-Dtest=GtfsTransformerTest" -pl onebusaway-gtfs-transformer test`

Focused transformer tests pass with 0 failures and 0 errors.

**Notes:**

The full reactor on Windows currently has two pre-existing CRLF-sensitive failures in `IndividualCsvEntityWriterTest`. This pull request does not modify those tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-gtfs-modules/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787896055&installation_model_id=429412&pr_number=474&repository=OneBusAway%2Fonebusaway-gtfs-modules&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-gtfs-modules%2Fpull%2F474&signature=172f2fe3e7f73b12eada414ce13adf8c8c6e3a9333b81cf714ad3af8abb80af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP output paths are now recognized regardless of capitalization, including `.ZIP`.
  * Prevents uppercase ZIP filenames from being incorrectly treated as directories.
  * Ensures correctly generated ZIP archives contain the expected GTFS files.

* **Tests**
  * Added coverage verifying uppercase ZIP output is created and packaged correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->