### PR TITLE
Fix removal of trips with empty shape_id

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/deferred/DeferredValueMatcher.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/deferred/DeferredValueMatcher.java
@@ -36,7 +36,7 @@ public class DeferredValueMatcher implements ValueMatcher {
 
   public boolean matches(Class<?> parentEntityType, String propertyName, Object value) {
     if (value == null) {
-      return _value == null;
+      return _value == null || (_value instanceof String stringValue && stringValue.isEmpty());
     } else if (_value == null) {
       return false;
     }

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/GtfsTransformerTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/GtfsTransformerTest.java
@@ -20,14 +20,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.serialization.GtfsReader;
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.onebusaway.gtfs.services.MockGtfs;
 import org.onebusaway.gtfs_transformer.updates.UpdateLibrary;
@@ -142,6 +148,38 @@ public class GtfsTransformerTest {
   }
 
   @Test
+  public void testRemoveTripsWithEmptyShapeIdFromGtfsInput() throws Exception {
+    URL resource = getClass().getResource("/org/onebusaway/gtfs_transformer/testagency");
+    assertNotNull(resource);
+    Path inputDirectory = Path.of(resource.toURI());
+
+    GtfsRelationalDao inputDao = readDao(inputDirectory);
+    assertEquals(15, inputDao.getAllTrips().size());
+    assertEquals(11, inputDao.getAllTrips().stream().filter(t -> t.getShapeId() == null).count());
+    assertEquals(4, inputDao.getAllTrips().stream().filter(t -> t.getShapeId() != null).count());
+
+    GtfsTransformer transformer = new GtfsTransformer();
+    transformer
+        .getTransformFactory()
+        .addModificationsFromString("{'op':'remove','match':{'file':'trips.txt','shape_id':''}}");
+    transformer.setGtfsInputDirectory(inputDirectory.toFile());
+    transformer.run();
+
+    GtfsRelationalDao transformedDao = transformer.getDao();
+    UpdateLibrary.clearDaoCache(transformedDao);
+
+    assertEquals(4, transformedDao.getAllTrips().size());
+    Set<String> remainingTripIds =
+        transformedDao.getAllTrips().stream()
+            .map(trip -> trip.getId().getId())
+            .collect(Collectors.toSet());
+    assertEquals(Set.of("4.1", "4.2", "4.3", "5.1"), remainingTripIds);
+    for (Trip trip : transformedDao.getAllTrips()) {
+      assertNotNull(trip.getShapeId());
+    }
+  }
+
+  @Test
   public void testUppercaseZipOutput(@TempDir Path tempDir) throws Exception {
     Path output = tempDir.resolve("output.ZIP");
     _transformer.setGtfsInputDirectory(_gtfs.getPath());
@@ -162,6 +200,15 @@ public class GtfsTransformerTest {
     _transformer.run();
     GtfsRelationalDao dao = _transformer.getDao();
     UpdateLibrary.clearDaoCache(dao);
+    return dao;
+  }
+
+  private GtfsRelationalDao readDao(Path inputDirectory) throws IOException {
+    GtfsReader reader = new GtfsReader();
+    reader.setInputLocation(inputDirectory.toFile());
+    GtfsRelationalDaoImpl dao = new GtfsRelationalDaoImpl();
+    reader.setEntityStore(dao);
+    reader.run();
     return dao;
   }
 }

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/deferred/DeferredValueMatcherTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/deferred/DeferredValueMatcherTest.java
@@ -85,6 +85,30 @@ public class DeferredValueMatcherTest {
     assertFalse(matcher.matches(Route.class, "id", new AgencyAndId("1", "R20")));
   }
 
+  @Test
+  public void testNullValue() {
+    DeferredValueMatcher matcher = matcher(null);
+    assertTrue(matcher.matches(Trip.class, "shapeId", null));
+  }
+
+  @Test
+  public void testEmptyStringMatchesNullValue() {
+    DeferredValueMatcher matcher = matcher("");
+    assertTrue(matcher.matches(Trip.class, "shapeId", null));
+  }
+
+  @Test
+  public void testStringDoesNotMatchNullValue() {
+    DeferredValueMatcher matcher = matcher("shape-1");
+    assertFalse(matcher.matches(Trip.class, "shapeId", null));
+  }
+
+  @Test
+  public void testStringMatchesAgencyAndIdValue() {
+    DeferredValueMatcher matcher = matcher("shape-1");
+    assertTrue(matcher.matches(Trip.class, "shapeId", new AgencyAndId("1", "shape-1")));
+  }
+
   private DeferredValueMatcher matcher(Object value) {
     return new DeferredValueMatcher(_reader, _schemaCache, value);
   }

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/factory/TransformFactoryTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/factory/TransformFactoryTest.java
@@ -72,6 +72,32 @@ public class TransformFactoryTest {
   }
 
   @Test
+  public void testRemoveTripWithEmptyShapeIdMatch()
+      throws IOException, TransformSpecificationException {
+    _factory.addModificationsFromString(
+        "{'op':'remove', " + "'match':{'file':'trips.txt', 'shape_id':''}}");
+    GtfsTransformStrategy transform = _transformer.getLastTransform();
+    TransformContext context = new TransformContext();
+    GtfsMutableRelationalDao dao = new GtfsRelationalDaoImpl();
+
+    Trip tripWithoutShape = new Trip();
+    tripWithoutShape.setId(new AgencyAndId("1", "T_NO_SHAPE"));
+    tripWithoutShape.setShapeId(null);
+    dao.saveEntity(tripWithoutShape);
+
+    Trip tripWithShape = new Trip();
+    tripWithShape.setId(new AgencyAndId("1", "T_WITH_SHAPE"));
+    tripWithShape.setShapeId(new AgencyAndId("1", "S1"));
+    dao.saveEntity(tripWithShape);
+
+    transform.run(context, dao);
+
+    assertFalse(dao.getAllTrips().contains(tripWithoutShape));
+    assertTrue(dao.getAllTrips().contains(tripWithShape));
+    assertEquals(1, dao.getAllTrips().size());
+  }
+
+  @Test
   public void testPathInUpdate() throws IOException, TransformSpecificationException {
     _factory.addModificationsFromString(
         "{'op':'update', "


### PR DESCRIPTION
**Summary:**

- Treat an empty configured match value as matching a null entity property.
- Fix removal of trips whose `shape_id` is empty after GTFS parsing.
- Add unit, transformer-level, and real GTFS integration regression tests.
- Preserve existing behavior for populated and whitespace-only values.

## Testing

- Verified the new regression tests fail against the original implementation.
- Verified all focused tests pass with the fix.
- Verified the complete `onebusaway-gtfs-transformer` test suite passes.

Closes #198

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-gtfs-modules/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787903994&installation_model_id=429412&pr_number=475&repository=OneBusAway%2Fonebusaway-gtfs-modules&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-gtfs-modules%2Fpull%2F475&signature=d868f98c67baaec1c4d65708ee2c597aed9ff284b86df2764227210af6afd90c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty `shape_id` matching now includes trips with missing (`null`) shape IDs.
  - Transformations that remove trips with empty shape IDs now consistently remove both empty and missing values.

- **Tests**
  - Added coverage for null, empty, matching, and non-matching shape ID values.
  - Added end-to-end validation using GTFS input files and transformation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->