### PR TITLE
Ignore unknown fields in locations GeoJSON #188

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReader.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReader.java
@@ -13,6 +13,7 @@
  */
 package org.onebusaway.gtfs.serialization;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
@@ -27,7 +28,13 @@ import org.onebusaway.gtfs.model.Location;
 public class LocationsGeoJSONReader {
 
   private static final ObjectReader FEATURE_COLLECTION_OBJECT_READER =
-      new ObjectMapper().readerFor(FeatureCollection.class);
+      createFeatureCollectionReader();
+
+  static ObjectReader createFeatureCollectionReader() {
+    return new ObjectMapper()
+        .readerFor(FeatureCollection.class)
+        .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+  }
 
   private final Reader reader;
   private final String defaultAgencyId;

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/FlexReaderTest.java
@@ -15,21 +15,63 @@ package org.onebusaway.gtfs.serialization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.geojson.LngLatAlt;
+import org.geojson.Polygon;
 import org.junit.jupiter.api.Test;
 import org.onebusaway.csv_entities.exceptions.CsvEntityIOException;
 import org.onebusaway.gtfs.GtfsTestData;
+import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Location;
 import org.onebusaway.gtfs.model.LocationGroup;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopTime;
+import org.onebusaway.gtfs.services.MockGtfs;
 
 public class FlexReaderTest extends BaseGtfsTest {
 
   private static final String AGENCY_ID = "1";
+
+  @Test
+  public void foreignGeoJsonMembersThroughCompleteGtfsIngestionPath() throws IOException {
+    MockGtfs gtfs = MockGtfs.create();
+    gtfs.putAgencies(1);
+    gtfs.putRoutes(1);
+    gtfs.putTrips(1, "r0", "service");
+    gtfs.putLines(
+        "stop_times.txt",
+        "trip_id,location_id,stop_sequence,arrival_time,departure_time",
+        "t0,si_Wendenschlossstrasse,1,09:00:00,09:00:00");
+    gtfs.putFile("locations.geojson", GtfsTestData.getLocationsGeojson());
+
+    var dao = gtfs.read();
+
+    AgencyAndId locationId = new AgencyAndId("a0", "si_Wendenschlossstrasse");
+    assertEquals(1, dao.getAllLocations().size());
+    Location location = dao.getEntityForId(Location.class, locationId);
+    assertNotNull(location);
+    assertEquals(locationId, location.getId());
+    assertEquals("Wendenschlossstrasse", location.getName());
+    assertEquals("A nice description", location.getDescription());
+    assertEquals("http://example.com", location.getUrl());
+    assertEquals("fare-zone-A", location.getZoneId());
+    assertEquals(
+        new Polygon(
+            new LngLatAlt(13.576526641845703, 52.44413508398945),
+            new LngLatAlt(13.575839996337889, 52.429169943434495),
+            new LngLatAlt(13.590774536132812, 52.4105872618342),
+            new LngLatAlt(13.60879898071289, 52.43225757383383),
+            new LngLatAlt(13.576526641845703, 52.44413508398945)),
+        location.getGeometry());
+
+    assertEquals(1, dao.getAllStopTimes().size());
+    StopTime stopTime = dao.getAllStopTimes().iterator().next();
+    assertSame(location, stopTime.getStopLocation());
+  }
 
   @Test
   public void locationIdAsASeparateColumn() throws CsvEntityIOException, IOException {

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReaderTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/serialization/LocationsGeoJSONReaderTest.java
@@ -14,11 +14,18 @@
 package org.onebusaway.gtfs.serialization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.Collection;
 import org.geojson.LngLatAlt;
 import org.geojson.Polygon;
@@ -29,16 +36,25 @@ import org.onebusaway.gtfs.model.Location;
 public class LocationsGeoJSONReaderTest {
 
   @Test
+  public void featureCollectionReaderAllowsForeignMembers() {
+    assertFalse(
+        LocationsGeoJSONReader.createFeatureCollectionReader()
+            .isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+  }
+
+  @Test
   public void read() throws IOException {
     Collection<Location> locations =
         new LocationsGeoJSONReader(
-                new InputStreamReader(new FileInputStream(GtfsTestData.getLocationsGeojson())), "")
+                new InputStreamReader(new FileInputStream(GtfsTestData.getLocationsGeojson())),
+                "agency")
             .read();
 
-    assertEquals(locations.size(), 1);
+    assertEquals(1, locations.size());
 
     Location location = locations.iterator().next();
 
+    assertEquals("agency", location.getId().getAgencyId());
     assertEquals("si_Wendenschlossstrasse", location.getId().getId());
     assertEquals("Wendenschlossstrasse", location.getName());
     assertEquals("A nice description", location.getDescription());
@@ -57,5 +73,38 @@ public class LocationsGeoJSONReaderTest {
     assertEquals("fare-zone-A", location.getZoneId());
 
     assertEquals("http://example.com", location.getUrl());
+  }
+
+  @Test
+  public void foreignMembersAreDiscarded() throws IOException {
+    Collection<Location> locations =
+        new LocationsGeoJSONReader(
+                new InputStreamReader(new FileInputStream(GtfsTestData.getLocationsGeojson())),
+                "agency")
+            .read();
+    StringWriter output = new StringWriter();
+
+    new LocationsGeoJSONWriter(output).write(locations);
+
+    JsonNode writtenGeoJson = new ObjectMapper().readTree(output.toString());
+    assertFalse(writtenGeoJson.has("foreign_collection_member"));
+    JsonNode feature = writtenGeoJson.get("features").get(0);
+    assertFalse(feature.has("style"));
+    assertFalse(feature.get("geometry").has("foreign_geometry_member"));
+  }
+
+  @Test
+  public void invalidRecognizedStructureFails() {
+    String invalidGeoJson =
+        """
+        {
+          "type": "FeatureCollection",
+          "features": {}
+        }
+        """;
+
+    assertThrows(
+        IOException.class,
+        () -> new LocationsGeoJSONReader(new StringReader(invalidGeoJson), "").read());
   }
 }

--- a/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/locations.geojson
+++ b/onebusaway-gtfs/src/test/resources/org/onebusaway/gtfs/locations.geojson
@@ -1,10 +1,21 @@
 
 {
   "type": "FeatureCollection",
+  "foreign_collection_member": {
+    "nested": {
+      "value": true
+    }
+  },
   "features": [
     {
       "type": "Feature",
       "id": "si_Wendenschlossstrasse",
+      "style": {
+        "color": "#ff0000",
+        "metadata": {
+          "source": "issue-188"
+        }
+      },
       "properties": {
         "stop_name": "Wendenschlossstrasse",
         "stop_desc": "A nice description",
@@ -13,6 +24,9 @@
       },
       "geometry": {
         "type": "Polygon",
+        "foreign_geometry_member": {
+          "nested": "ignored"
+        },
         "coordinates": [
           [
             [13.576526641845703,52.44413508398945],


### PR DESCRIPTION
## Summary

Configure the GeoJSON test fixtures to verify that unknown fields are ignored during deserialization.

## Changes

- Added unknown fields at the FeatureCollection level
- Added unknown fields at the Feature level
- Added unknown fields inside geometry
- Updated the related GeoJSON test resources

## Validation

- 11 focused tests passed on JDK 25
- Spotless passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GeoJSON location data now tolerates unrecognized properties while continuing to validate recognized structures.
  * Imported location data preserves supported attributes, geometry, and stop-time relationships.
  * Unsupported foreign GeoJSON members are excluded when data is written.

* **Tests**
  * Expanded coverage for complete flexible GTFS ingestion, nested GeoJSON properties, and malformed feature collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->